### PR TITLE
✨Feature: Quest 대시보드 랜딩 페이지

### DIFF
--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,0 +1,8 @@
+import { JetBrains_Mono } from 'next/font/google'
+
+export const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-jetbrains-mono',
+  weight: ['500', '700'],
+})

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
 @theme {
   --animate-float: float 3s ease-in-out infinite;
   --animate-wiggle: wiggle 0.6s ease-in-out infinite;
+  --animate-quest-bounce: quest-bounce 2s ease-in-out infinite;
 }
 
 @keyframes float {
@@ -28,7 +29,22 @@
   }
 }
 
+@keyframes quest-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
 body {
-  background: var(--color-surface);
-  color: var(--color-on-surface);
+  background: var(--quest-bg);
+  color: var(--quest-text);
+  word-break: keep-all;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next'
 import Header from '@/components/layout/Header'
 import Footer from '@/components/layout/Footer'
+import { jetbrainsMono } from './fonts'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: '🎮 React Playground',
-  description: '훅이 뭔지 감이 안 와? 일단 눌러보고 망가뜨려봐.',
+  title: '🎮 React Quest',
+  description: '훅을 눌러보고, 망가뜨리고, 체화하는 놀이터',
 }
 
 export default function RootLayout({
@@ -14,7 +15,13 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang='ko'>
+    <html lang='ko' className={jetbrainsMono.variable}>
+      <head>
+        <link
+          rel='stylesheet'
+          href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css'
+        />
+      </head>
       <body className='flex min-h-screen flex-col antialiased'>
         <Header />
         <main className='flex-1'>{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,48 +1,40 @@
-import Badge from '@/components/ui/Badge'
-import Button from '@/components/ui/Button'
-import Card from '@/components/ui/Card'
+import Dashboard from '@/components/quest/Dashboard'
+import Legend from '@/components/quest/Legend'
+import QuestSection from '@/components/quest/QuestSection'
+import Achievement from '@/components/quest/Achievement'
+import { sections } from '@/data/stages'
+import { achievements } from '@/data/achievements'
 
 export default function Home() {
   return (
-    <div className='mx-auto max-w-6xl px-6 py-16 sm:py-24'>
-      <section className='flex flex-col items-center gap-6 text-center'>
-        <Badge label='🎢 놀이기구처럼 체험하는 React' theme='orange' />
-        <h1 className='text-4xl font-bold tracking-tight sm:text-6xl'>
-          훅이 뭔지 감이 안 와?
-          <br />
-          <span className='text-orange-500'>일단 눌러보고 망가뜨려봐.</span>
+    <div className='mx-auto max-w-240 px-6 py-12'>
+      <section className='mb-14 text-center'>
+        <div className='animate-quest-bounce mb-4 text-7xl'>🎮</div>
+        <h1 className='mb-3 text-5xl font-black tracking-[-0.02em] sm:text-[56px]'>
+          React <span className='text-[#ff5e48]'>Quest</span>
         </h1>
-        <p className='max-w-xl text-base text-gray-500 sm:text-lg'>
-          학술적인 설명은 그만. useState, useEffect, useReducer… 직접 손으로
-          만져보는 React 훅 놀이터.
+        <p className='text-lg text-gray-500'>
+          훅을 눌러보고, 망가뜨리고, 체화하는 놀이터
         </p>
-        <div className='flex flex-wrap justify-center gap-3'>
-          <Button label='🎮 훅 둘러보기' size='lg' href='/hooks' />
-          <Button label='About' size='lg' variant='white' href='/about' />
-        </div>
       </section>
 
-      <section className='mt-24 grid gap-4 sm:grid-cols-3'>
-        <Card theme='lightOrange' interactive>
-          <h3 className='text-xl font-bold'>useState</h3>
-          <p className='mt-2 text-sm text-gray-600'>
-            상태가 바뀌면 화면이 바뀐다. 버튼을 누르고 숫자가 요동치는 걸
-            구경하자.
-          </p>
-        </Card>
-        <Card theme='lightSky' interactive>
-          <h3 className='text-xl font-bold'>useEffect</h3>
-          <p className='mt-2 text-sm text-gray-600'>
-            언제 실행될지, 왜 무한루프에 빠지는지 — 의존성 배열을 직접
-            괴롭혀보자.
-          </p>
-        </Card>
-        <Card theme='gray' interactive>
-          <h3 className='text-xl font-bold'>useReducer</h3>
-          <p className='mt-2 text-sm text-gray-600'>
-            상태가 복잡해지면? 액션을 쏘고 리듀서가 받는 구조를 놀이기구로 체험.
-          </p>
-        </Card>
+      <Dashboard />
+      <Legend />
+
+      {sections.map((section) => (
+        <QuestSection key={section.id} section={section} />
+      ))}
+
+      <section className='mb-12'>
+        <header className='mb-6 border-b-2 border-gray-100 pb-4'>
+          <h2 className='mb-1 text-2xl font-extrabold'>🏆 획득 뱃지</h2>
+          <p className='text-sm text-gray-500'>스테이지를 깨면 해금됩니다</p>
+        </header>
+        <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-6'>
+          {achievements.map((a) => (
+            <Achievement key={a.id} achievement={a} />
+          ))}
+        </div>
       </section>
     </div>
   )

--- a/src/app/styles/theme.css
+++ b/src/app/styles/theme.css
@@ -34,6 +34,33 @@
   /* Green */
   --green-500: #00e8bd;
 
+  /* Quest 전용 팔레트 — 게임 UI 의미 색상 */
+  --quest-bg: #fffbf5;
+  --quest-primary: #ff5e48;
+  --quest-primary-soft: #ffe8e3;
+  --quest-success: #10b981;
+  --quest-success-soft: #d1fae5;
+  --quest-warning: #f59e0b;
+  --quest-warning-soft: #fef3c7;
+  --quest-danger: #ef4444;
+  --quest-purple: #8b5cf6;
+  --quest-purple-soft: #ede9fe;
+  --quest-pink: #ec4899;
+  --quest-tutorial-bg: #dbeafe;
+  --quest-tutorial-fg: #1e40af;
+  --quest-easy-bg: #d1fae5;
+  --quest-easy-fg: #065f46;
+  --quest-medium-bg: #fef3c7;
+  --quest-medium-fg: #92400e;
+  --quest-hard-bg: #fee2e2;
+  --quest-hard-fg: #991b1b;
+  --quest-bonus-bg: #fce7f3;
+  --quest-bonus-fg: #be185d;
+  --quest-border: #f3f4f6;
+  --quest-border-strong: #e5e7eb;
+  --quest-text: #111827;
+  --quest-text-muted: #6b7280;
+
   /* Radius */
   --radius-sm: 1.125rem;
   --radius-md: 1.25rem;
@@ -70,9 +97,11 @@
 
 @theme {
   --font-sans:
-    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    'Pretendard Variable', 'Pretendard', ui-sans-serif, system-ui,
+    -apple-system, 'Segoe UI', Roboto, sans-serif;
   --font-mono:
-    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    var(--font-jetbrains-mono), 'JetBrains Mono', ui-monospace, SFMono-Regular,
+    Menlo, Monaco, monospace;
 
   /* Grayscale */
   --color-gray-50: var(--gray-50);
@@ -130,4 +159,31 @@
   --color-surface-alt: var(--color-surface-alt);
   --color-on-surface: var(--color-on-surface);
   --color-on-surface-muted: var(--color-on-surface-muted);
+
+  /* Quest 전용 색상 토큰 */
+  --color-quest-bg: var(--quest-bg);
+  --color-quest-primary: var(--quest-primary);
+  --color-quest-primary-soft: var(--quest-primary-soft);
+  --color-quest-success: var(--quest-success);
+  --color-quest-success-soft: var(--quest-success-soft);
+  --color-quest-warning: var(--quest-warning);
+  --color-quest-warning-soft: var(--quest-warning-soft);
+  --color-quest-danger: var(--quest-danger);
+  --color-quest-purple: var(--quest-purple);
+  --color-quest-purple-soft: var(--quest-purple-soft);
+  --color-quest-pink: var(--quest-pink);
+  --color-quest-tutorial-bg: var(--quest-tutorial-bg);
+  --color-quest-tutorial-fg: var(--quest-tutorial-fg);
+  --color-quest-easy-bg: var(--quest-easy-bg);
+  --color-quest-easy-fg: var(--quest-easy-fg);
+  --color-quest-medium-bg: var(--quest-medium-bg);
+  --color-quest-medium-fg: var(--quest-medium-fg);
+  --color-quest-hard-bg: var(--quest-hard-bg);
+  --color-quest-hard-fg: var(--quest-hard-fg);
+  --color-quest-bonus-bg: var(--quest-bonus-bg);
+  --color-quest-bonus-fg: var(--quest-bonus-fg);
+  --color-quest-border: var(--quest-border);
+  --color-quest-border-strong: var(--quest-border-strong);
+  --color-quest-text: var(--quest-text);
+  --color-quest-text-muted: var(--quest-text-muted);
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,9 +1,33 @@
+const links = [
+  { href: 'https://narae-ux-portfolio.vercel.app', label: '🎨 UX 포트폴리오' },
+  { href: 'https://jerryko570.github.io', label: "📝 Jerry's blog" },
+  {
+    href: 'https://github.com/jerryko570/jerry-react-quest',
+    label: '💻 GitHub',
+  },
+]
+
 export default function Footer() {
   return (
-    <footer className='mt-auto border-t border-gray-100 bg-white py-6'>
-      <div className='mx-auto flex max-w-6xl flex-col items-center justify-between gap-2 px-6 text-sm text-gray-500 sm:flex-row'>
-        <p>© {new Date().getFullYear()} React Playground</p>
-        <p className='text-xs'>일단 눌러보고 망가뜨려봐 🔨</p>
+    <footer className='mt-14 bg-gradient-to-br from-[#fff8ec] to-[#fef0e8]'>
+      <div className='mx-auto max-w-240 px-6 py-10 text-center'>
+        <h3 className='mb-2 text-lg font-extrabold'>🔗 연결된 자산들</h3>
+        <p className='mb-5 text-sm text-gray-500'>
+          React Quest는 다른 프로젝트들과 이어져 있어요
+        </p>
+        <div className='flex flex-wrap justify-center gap-3'>
+          {links.map(({ href, label }) => (
+            <a
+              key={href}
+              href={href}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex items-center gap-2 rounded-full border-2 border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 transition-all duration-200 hover:-translate-y-0.5 hover:border-[#ff5e48] hover:text-[#ff5e48]'
+            >
+              {label}
+            </a>
+          ))}
+        </div>
       </div>
     </footer>
   )

--- a/src/components/quest/Achievement.tsx
+++ b/src/components/quest/Achievement.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/lib/cn'
+import type { Achievement as AchievementType } from '@/data/achievements'
+
+type AchievementProps = {
+  achievement: AchievementType
+}
+
+export default function Achievement({ achievement }: AchievementProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border-2 p-5 text-center transition-all duration-300',
+        achievement.unlocked
+          ? 'border-[#f59e0b] bg-[#fef3c7]'
+          : 'border-gray-100 bg-white opacity-40 grayscale'
+      )}
+    >
+      <div className='mb-2 text-4xl'>{achievement.emoji}</div>
+      <div className='mb-1 text-[13px] font-bold'>{achievement.title}</div>
+      <div className='text-[11px] text-gray-500'>{achievement.description}</div>
+    </div>
+  )
+}

--- a/src/components/quest/Dashboard.tsx
+++ b/src/components/quest/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { allStages, totalExamples, totalStages } from '@/data/stages'
+import { totalExamples, totalStages } from '@/data/stages'
 import { achievements } from '@/data/achievements'
 
 type DashboardProps = {
@@ -20,9 +20,6 @@ export default function Dashboard({
     totalStages === 0 ? 0 : Math.round((stagesDone / totalStages) * 100)
   const badgesTotal = achievements.length
 
-  // allStages는 각 stage 메타 계산에 사용 (향후 확장용)
-  void allStages
-
   return (
     <section className='mb-12 rounded-3xl bg-gradient-to-br from-[#ff5e48] to-[#ff8a65] p-8 text-white shadow-[0_20px_40px_-20px_rgba(255,94,72,0.4)]'>
       <div className='mb-5 flex flex-wrap items-end justify-between gap-3'>
@@ -31,7 +28,7 @@ export default function Dashboard({
             ⚔️ 전체 진도
           </div>
           <div className='mt-1 text-sm opacity-85'>
-            책: 모던 리액트 Deep Dive
+            프론트엔드 디자이너의 React 정복 퀘스트
           </div>
         </div>
         <div className='font-mono text-5xl leading-none font-bold'>

--- a/src/components/quest/Dashboard.tsx
+++ b/src/components/quest/Dashboard.tsx
@@ -1,0 +1,66 @@
+import { allStages, totalExamples, totalStages } from '@/data/stages'
+import { achievements } from '@/data/achievements'
+
+type DashboardProps = {
+  stagesDone?: number
+  examplesDone?: number
+  postsDone?: number
+  postsTotal?: number
+  badgesDone?: number
+}
+
+export default function Dashboard({
+  stagesDone = 0,
+  examplesDone = 0,
+  postsDone = 0,
+  postsTotal = 11,
+  badgesDone = 0,
+}: DashboardProps) {
+  const percent =
+    totalStages === 0 ? 0 : Math.round((stagesDone / totalStages) * 100)
+  const badgesTotal = achievements.length
+
+  // allStages는 각 stage 메타 계산에 사용 (향후 확장용)
+  void allStages
+
+  return (
+    <section className='mb-12 rounded-3xl bg-gradient-to-br from-[#ff5e48] to-[#ff8a65] p-8 text-white shadow-[0_20px_40px_-20px_rgba(255,94,72,0.4)]'>
+      <div className='mb-5 flex flex-wrap items-end justify-between gap-3'>
+        <div>
+          <div className='text-xs font-semibold tracking-[0.1em] uppercase opacity-90'>
+            ⚔️ 전체 진도
+          </div>
+          <div className='mt-1 text-sm opacity-85'>
+            책: 모던 리액트 Deep Dive
+          </div>
+        </div>
+        <div className='font-mono text-5xl leading-none font-bold'>
+          {percent}%
+        </div>
+      </div>
+
+      <div className='mb-6 h-3 overflow-hidden rounded-full bg-white/20'>
+        <div
+          className='h-full rounded-full bg-white transition-[width] duration-700 ease-out'
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      <div className='grid grid-cols-2 gap-4 sm:grid-cols-4'>
+        <Stat label='🎯 스테이지' value={`${stagesDone} / ${totalStages}`} />
+        <Stat label='🧪 예제' value={`${examplesDone} / ${totalExamples}`} />
+        <Stat label='📝 블로그' value={`${postsDone} / ${postsTotal}`} />
+        <Stat label='🏆 뱃지' value={`${badgesDone} / ${badgesTotal}`} />
+      </div>
+    </section>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className='rounded-2xl bg-white/15 p-4 backdrop-blur-md'>
+      <div className='mb-1 text-xs font-semibold opacity-85'>{label}</div>
+      <div className='font-mono text-2xl font-bold'>{value}</div>
+    </div>
+  )
+}

--- a/src/components/quest/Legend.tsx
+++ b/src/components/quest/Legend.tsx
@@ -1,0 +1,19 @@
+const items = [
+  { icon: '✅', label: '완료' },
+  { icon: '🔓', label: '진행 가능' },
+  { icon: '🔒', label: '잠김' },
+  { icon: '👑', label: '보스전' },
+]
+
+export default function Legend() {
+  return (
+    <div className='mb-8 flex flex-wrap gap-5 rounded-2xl bg-white px-6 py-5 text-sm text-gray-500'>
+      {items.map(({ icon, label }) => (
+        <div key={label} className='flex items-center gap-1.5'>
+          <span>{icon}</span>
+          <span>{label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/quest/QuestSection.tsx
+++ b/src/components/quest/QuestSection.tsx
@@ -1,0 +1,23 @@
+import type { Section } from '@/data/stages'
+import StageCard from './StageCard'
+
+type QuestSectionProps = {
+  section: Section
+}
+
+export default function QuestSection({ section }: QuestSectionProps) {
+  return (
+    <section className='mb-12'>
+      <header className='mb-6 border-b-2 border-gray-100 pb-4'>
+        <h2 className='mb-1 text-2xl font-extrabold'>{section.label}</h2>
+        <p className='text-sm text-gray-500'>{section.sublabel}</p>
+      </header>
+
+      <div className='flex flex-col gap-4'>
+        {section.stages.map((stage) => (
+          <StageCard key={stage.id} stage={stage} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -1,0 +1,112 @@
+import type { Stage } from '@/data/stages'
+import { cn } from '@/lib/cn'
+import {
+  difficultyBadge,
+  difficultyLabel,
+  stageCardVariants,
+} from './StageCard.variants'
+
+type StageCardProps = {
+  stage: Stage
+}
+
+export default function StageCard({ stage }: StageCardProps) {
+  const statusIcon =
+    stage.status === 'completed'
+      ? '✅'
+      : stage.status === 'active'
+        ? '🔓'
+        : '🔒'
+
+  return (
+    <article
+      className={cn(
+        stageCardVariants({ status: stage.status, boss: stage.isBoss }),
+        stage.status === 'locked' && 'hover:translate-y-0 hover:shadow-none'
+      )}
+    >
+      {stage.isBoss && (
+        <div className='absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#8b5cf6] via-[#ec4899] to-[#f59e0b]' />
+      )}
+
+      <header className='mb-4 flex items-start justify-between gap-3'>
+        <div className='flex flex-1 items-center gap-4'>
+          <span className='shrink-0 text-4xl'>{stage.emoji}</span>
+          <div>
+            <h3 className='text-xl font-extrabold tracking-[-0.01em]'>
+              {stage.title}
+            </h3>
+            <p className='text-sm text-gray-500'>{stage.subtitle}</p>
+            <div className='mt-2 flex flex-wrap items-center gap-1.5'>
+              <span
+                className={difficultyBadge({ difficulty: stage.difficulty })}
+              >
+                {difficultyLabel[stage.difficulty]}
+              </span>
+              {stage.highlight && (
+                <span className='text-xs font-bold text-[#ff5e48]'>
+                  {stage.highlight}
+                </span>
+              )}
+              <span className='text-xs text-gray-500'>⏱ {stage.hours}시간</span>
+            </div>
+          </div>
+        </div>
+        <div className='shrink-0 text-2xl'>{statusIcon}</div>
+      </header>
+
+      <div className='border-t border-gray-100 pt-4'>
+        <div className='mb-3 inline-block rounded-lg bg-gray-100 px-2.5 py-1 font-mono text-xs text-gray-500'>
+          📖 {stage.bookRef}
+        </div>
+
+        <div className='mt-4 grid gap-5 md:grid-cols-2'>
+          <Bullets title='🎯 학습 목표' items={stage.goals} />
+          <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
+        </div>
+      </div>
+
+      {stage.progress && (
+        <footer className='mt-4 flex items-center justify-between border-t border-gray-100 pt-4 text-sm text-gray-500'>
+          <span>{stage.progress.label}</span>
+          <div className='flex items-center gap-2'>
+            <div className='h-1.5 w-24 overflow-hidden rounded-full bg-gray-100'>
+              <div
+                className='h-full rounded-full bg-[#ff5e48]'
+                style={{
+                  width: `${Math.round(
+                    (stage.progress.current / stage.progress.total) * 100
+                  )}%`,
+                }}
+              />
+            </div>
+            <span className='font-mono'>
+              {stage.progress.current}/{stage.progress.total}
+            </span>
+          </div>
+        </footer>
+      )}
+    </article>
+  )
+}
+
+function Bullets({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <div className='mb-2 flex items-center gap-1.5 text-xs font-bold tracking-[0.08em] text-gray-500 uppercase'>
+        {title}
+      </div>
+      <ul className='flex flex-col gap-1.5'>
+        {items.map((text) => (
+          <li
+            key={text}
+            className='flex items-start gap-2 text-sm leading-snug'
+          >
+            <span className='shrink-0 font-mono text-gray-500'>☐</span>
+            <span>{text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -55,15 +55,9 @@ export default function StageCard({ stage }: StageCardProps) {
         <div className='shrink-0 text-2xl'>{statusIcon}</div>
       </header>
 
-      <div className='border-t border-gray-100 pt-4'>
-        <div className='mb-3 inline-block rounded-lg bg-gray-100 px-2.5 py-1 font-mono text-xs text-gray-500'>
-          📖 {stage.bookRef}
-        </div>
-
-        <div className='mt-4 grid gap-5 md:grid-cols-2'>
-          <Bullets title='🎯 학습 목표' items={stage.goals} />
-          <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
-        </div>
+      <div className='grid gap-5 border-t border-gray-100 pt-4 md:grid-cols-2'>
+        <Bullets title='🎯 학습 목표' items={stage.goals} />
+        <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
       </div>
 
       {stage.progress && (

--- a/src/components/quest/StageCard.variants.ts
+++ b/src/components/quest/StageCard.variants.ts
@@ -1,0 +1,55 @@
+import { cva } from 'class-variance-authority'
+
+export const stageCardVariants = cva(
+  'relative overflow-hidden rounded-[20px] border-2 p-6 transition-all duration-300',
+  {
+    variants: {
+      status: {
+        locked: 'border-gray-200 bg-gray-50/80 opacity-55',
+        active:
+          'border-[#ff5e48] bg-white shadow-[0_0_0_4px_#ffe8e3] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-8px_rgba(0,0,0,0.1)]',
+        completed:
+          'border-[#10b981] bg-[#d1fae5] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-8px_rgba(0,0,0,0.1)]',
+      },
+      boss: {
+        true: 'border-[#8b5cf6] bg-gradient-to-br from-white to-[#f5f3ff]',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      status: 'locked',
+      boss: false,
+    },
+  }
+)
+
+export const difficultyBadge = cva(
+  'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-bold tracking-[0.05em] uppercase',
+  {
+    variants: {
+      difficulty: {
+        tutorial: 'bg-[#dbeafe] text-[#1e40af]',
+        easy: 'bg-[#d1fae5] text-[#065f46]',
+        medium: 'bg-[#fef3c7] text-[#92400e]',
+        hard: 'bg-[#fee2e2] text-[#991b1b]',
+        boss: 'bg-gradient-to-r from-[#8b5cf6] to-[#ec4899] text-white',
+        bonus: 'bg-[#fce7f3] text-[#be185d]',
+      },
+    },
+    defaultVariants: {
+      difficulty: 'tutorial',
+    },
+  }
+)
+
+export const difficultyLabel: Record<
+  NonNullable<Parameters<typeof difficultyBadge>[0]>['difficulty'] & string,
+  string
+> = {
+  tutorial: 'Tutorial',
+  easy: 'Easy',
+  medium: 'Medium',
+  hard: 'Hard',
+  boss: 'BOSS',
+  bonus: 'BONUS',
+}

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -1,0 +1,52 @@
+export type Achievement = {
+  id: string
+  emoji: string
+  title: string
+  description: string
+  unlocked: boolean
+}
+
+export const achievements: Achievement[] = [
+  {
+    id: 'first-render',
+    emoji: '🎬',
+    title: 'First Render',
+    description: 'STAGE 1 클리어',
+    unlocked: false,
+  },
+  {
+    id: 'memo-master',
+    emoji: '🧙‍♂️',
+    title: '메모리 마스터',
+    description: 'useMemo 정복',
+    unlocked: false,
+  },
+  {
+    id: 'shield-knight',
+    emoji: '🛡️',
+    title: '방패의 기사',
+    description: '3종 세트 완성',
+    unlocked: false,
+  },
+  {
+    id: 'hook-artisan',
+    emoji: '🔨',
+    title: '훅 장인',
+    description: '커스텀 훅 6개',
+    unlocked: false,
+  },
+  {
+    id: 'debugger',
+    emoji: '🐛',
+    title: '디버거',
+    description: '보스전 클리어',
+    unlocked: false,
+  },
+  {
+    id: 'react-wizard',
+    emoji: '👑',
+    title: 'React Wizard',
+    description: '전 스테이지 완주',
+    unlocked: false,
+  },
+]

--- a/src/data/stages.ts
+++ b/src/data/stages.ts
@@ -21,7 +21,6 @@ export type Stage = {
   emoji: string
   difficulty: Difficulty
   hours: number
-  bookRef: string
   status: StageStatus
   goals: string[]
   examples: string[]
@@ -51,7 +50,6 @@ export const sections: Section[] = [
         emoji: '🎬',
         difficulty: 'tutorial',
         hours: 2,
-        bookRef: '책 2.4 ~ 2.5 · p.172~188',
         status: 'locked',
         goals: [
           '리액트가 언제 다시 렌더링되는지',
@@ -71,17 +69,17 @@ export const sections: Section[] = [
   },
   {
     id: 'memoization',
-    label: '🟡 메모이제이션 3종 세트 ⭐',
-    sublabel: '지금 가장 궁금한 것 — useMemo, useCallback, React.memo',
+    label: '🟡 메모이제이션 3종 + Compiler ⭐',
+    sublabel:
+      '지금 가장 궁금한 것 — useMemo · useCallback · React.memo · Compiler',
     stages: [
       {
         id: 'stage-2-usememo',
-        title: 'STAGE 2 · useMemo',
+        title: 'STAGE · useMemo',
         subtitle: '값을 기억하는 마법',
         emoji: '🧙‍♂️',
         difficulty: 'easy',
         hours: 3,
-        bookRef: '책 3.1.3 · p.208~209',
         status: 'active',
         highlight: '⭐ 지금 시작!',
         goals: [
@@ -102,12 +100,11 @@ export const sections: Section[] = [
       },
       {
         id: 'stage-3-usecallback',
-        title: 'STAGE 3 · useCallback',
+        title: 'STAGE · useCallback',
         subtitle: '함수를 기억하는 마법',
         emoji: '🎯',
         difficulty: 'easy',
         hours: 3,
-        bookRef: '책 3.1.4 · p.210~215',
         status: 'locked',
         goals: [
           'useCallback과 useMemo의 관계',
@@ -124,12 +121,11 @@ export const sections: Section[] = [
       },
       {
         id: 'stage-4-react-memo',
-        title: 'STAGE 4 · React.memo',
+        title: 'STAGE · React.memo',
         subtitle: '자식을 보호하는 방패',
         emoji: '🛡️',
         difficulty: 'medium',
         hours: 4,
-        bookRef: '책 2.5 심화 · p.182~188',
         status: 'locked',
         goals: [
           'React.memo 동작 원리 (shallow compare)',
@@ -144,6 +140,28 @@ export const sections: Section[] = [
         ],
         examplesLabel: '만들 예제 (3개)',
       },
+      {
+        id: 'stage-react-compiler',
+        title: 'STAGE · React Compiler',
+        subtitle: '수동 메모이제이션은 과거형이 된다',
+        emoji: '🤖',
+        difficulty: 'hard',
+        hours: 4,
+        status: 'locked',
+        goals: [
+          'React Compiler가 무엇을 자동화하는지',
+          '언제 수동 useMemo / useCallback이 여전히 필요한지',
+          'eslint-plugin-react-compiler 설정',
+          '컴파일러 친화적 코드 스타일',
+          '3종 세트와의 새로운 관계',
+        ],
+        examples: [
+          'Before/After 컴파일 결과 비교',
+          '자동 메모이제이션 확인',
+          '컴파일러가 놓치는 케이스',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
     ],
   },
   {
@@ -153,12 +171,11 @@ export const sections: Section[] = [
     stages: [
       {
         id: 'stage-5-usestate',
-        title: 'STAGE 5 · useState 깊게',
+        title: 'STAGE · useState 깊게',
         subtitle: '얕게 쓰다 당한 버그들',
         emoji: '📦',
         difficulty: 'medium',
         hours: 3,
-        bookRef: '책 3.1.1 · p.189~195',
         status: 'locked',
         goals: [
           '배치 업데이트(batching)',
@@ -175,12 +192,11 @@ export const sections: Section[] = [
       },
       {
         id: 'stage-6-useeffect',
-        title: 'STAGE 6 · useEffect 깊게',
+        title: 'STAGE · useEffect 깊게',
         subtitle: '안 써도 되는 경우가 더 많다',
         emoji: '⚡',
         difficulty: 'hard',
         hours: 4,
-        bookRef: '책 3.1.2 · p.196~207',
         status: 'locked',
         goals: [
           'useEffect는 생명주기 대체가 아니다',
@@ -196,6 +212,28 @@ export const sections: Section[] = [
         ],
         examplesLabel: '만들 예제 (3개)',
       },
+      {
+        id: 'stage-error-boundary',
+        title: 'STAGE · Error Boundary',
+        subtitle: '망가지는 걸 품위있게 담아내기',
+        emoji: '🧯',
+        difficulty: 'easy',
+        hours: 2,
+        status: 'locked',
+        goals: [
+          'Error Boundary가 잡는 것 / 못 잡는 것',
+          'react-error-boundary 패키지 활용',
+          'Suspense + Error Boundary 조합',
+          '복구 가능한 폴백 UI 설계',
+          'async 에러 핸들링 패턴',
+        ],
+        examples: [
+          '에러 바운더리 계층 실험',
+          '폴백 UI + 다시 시도 버튼',
+          'async 에러 잡아내기',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
     ],
   },
   {
@@ -205,12 +243,11 @@ export const sections: Section[] = [
     stages: [
       {
         id: 'stage-7-custom-hooks',
-        title: 'STAGE 7 · 커스텀 훅',
+        title: 'STAGE · 커스텀 훅',
         subtitle: '내 훅 만들기 실전',
         emoji: '🔨',
         difficulty: 'medium',
         hours: 5,
-        bookRef: '책 3.2 · p.239~251',
         status: 'locked',
         goals: [
           '커스텀 훅 설계 원칙',
@@ -230,12 +267,11 @@ export const sections: Section[] = [
       },
       {
         id: 'stage-8-useref',
-        title: 'STAGE 8 · useRef',
+        title: 'STAGE · useRef',
         subtitle: 'DOM과 값의 두 얼굴',
         emoji: '🎯',
         difficulty: 'easy',
         hours: 2,
-        bookRef: '책 3.1.5 · p.216~218',
         status: 'locked',
         goals: [
           'useRef의 2가지 용도',
@@ -249,6 +285,52 @@ export const sections: Section[] = [
         ],
         examplesLabel: '만들 예제 (3개)',
       },
+      {
+        id: 'stage-a11y',
+        title: 'STAGE · 접근성 (a11y)',
+        subtitle: '모두가 쓸 수 있어야 완성이야',
+        emoji: '♿',
+        difficulty: 'medium',
+        hours: 4,
+        status: 'locked',
+        goals: [
+          'ARIA 속성의 기본 원리',
+          '키보드 네비게이션 (focus trap)',
+          'useId로 label-input 연결',
+          '스크린 리더 테스트 워크플로우',
+          ':focus-visible · 포커스 관리',
+        ],
+        examples: [
+          '키보드만으로 탐색하는 모달',
+          '스크린 리더가 읽어주는 토스트',
+          '접근 가능한 탭 컴포넌트',
+          'Skip to content 링크',
+        ],
+        examplesLabel: '만들 예제 (4개)',
+      },
+      {
+        id: 'stage-testing',
+        title: 'STAGE · 테스트 (RTL + Vitest)',
+        subtitle: '리팩토링 두려움 없애기',
+        emoji: '🧪',
+        difficulty: 'medium',
+        hours: 5,
+        status: 'locked',
+        goals: [
+          'React Testing Library 철학 (user-centric)',
+          '쿼리 우선순위 (role > label > text)',
+          '커스텀 훅 테스트 (renderHook)',
+          'MSW로 네트워크 모킹',
+          '접근성 친화적 테스트 작성',
+        ],
+        examples: [
+          '카운터 컴포넌트 테스트',
+          '커스텀 훅 테스트 (useDebounce)',
+          'MSW로 API 목킹',
+          'userEvent vs fireEvent',
+        ],
+        examplesLabel: '만들 예제 (4개)',
+      },
     ],
   },
   {
@@ -258,12 +340,11 @@ export const sections: Section[] = [
     stages: [
       {
         id: 'stage-9-usecontext',
-        title: 'STAGE 9 · useContext',
+        title: 'STAGE · useContext',
         subtitle: '상태 관리 아니에요. 주입이에요.',
         emoji: '🌐',
         difficulty: 'medium',
         hours: 3,
-        bookRef: '책 3.1.6 · p.219~224',
         status: 'locked',
         goals: [
           'Context는 상태 관리 도구가 아니다',
@@ -275,12 +356,11 @@ export const sections: Section[] = [
       },
       {
         id: 'stage-10-usereducer',
-        title: 'STAGE 10 · useReducer',
+        title: 'STAGE · useReducer',
         subtitle: '복잡한 상태는 나눠 정복하라',
         emoji: '⚙️',
         difficulty: 'medium',
         hours: 3,
-        bookRef: '책 3.1.7 · p.225~228',
         status: 'locked',
         goals: [
           'useState vs useReducer 선택 기준',
@@ -289,6 +369,29 @@ export const sections: Section[] = [
         ],
         examples: ['Todo 리스트 (두 버전 비교)', '폼 상태 관리'],
         examplesLabel: '만들 예제 (2개)',
+      },
+      {
+        id: 'stage-tanstack-query',
+        title: 'STAGE · TanStack Query',
+        subtitle: '서버 상태는 별세계야',
+        emoji: '🛰️',
+        difficulty: 'medium',
+        hours: 5,
+        status: 'locked',
+        goals: [
+          '서버 상태 vs 클라이언트 상태',
+          '캐싱 · invalidate · refetch 전략',
+          'optimistic update 패턴',
+          'infinite query · pagination',
+          'useMutation 핵심',
+        ],
+        examples: [
+          '캐시 타임라인 시각화',
+          '낙관적 업데이트 vs 비관적',
+          '무한 스크롤 구현',
+          'Query + Mutation 전체 흐름',
+        ],
+        examplesLabel: '만들 예제 (4개)',
       },
     ],
   },
@@ -304,7 +407,6 @@ export const sections: Section[] = [
         emoji: '👑',
         difficulty: 'boss',
         hours: 5,
-        bookRef: '종합 · 실전 디버깅',
         status: 'locked',
         isBoss: true,
         goals: [
@@ -324,10 +426,54 @@ export const sections: Section[] = [
     ],
   },
   {
-    id: 'bonus',
-    label: '🎁 BONUS · Next.js 16 특별판',
-    sublabel: '나래님이 쓰고 있는 스택의 최신 기능',
+    id: 'modern',
+    label: '🔮 Modern React 19 + Next.js 16',
+    sublabel: '2026년을 살아남는 최신 감각',
     stages: [
+      {
+        id: 'stage-suspense-use',
+        title: 'STAGE · Suspense + use',
+        subtitle: '로딩 상태를 계단처럼 쌓기',
+        emoji: '⏳',
+        difficulty: 'hard',
+        hours: 4,
+        status: 'locked',
+        goals: [
+          'Suspense boundary 설계',
+          '`use` hook으로 Promise 언래핑',
+          'Suspense + Error Boundary 조합',
+          'Streaming SSR 원리',
+          '폴백 중첩 전략',
+        ],
+        examples: [
+          'Suspense fallback 중첩 UI',
+          '`use(fetchPromise)` 패턴',
+          'Streaming 체험 데모',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+      {
+        id: 'stage-react-19-actions',
+        title: 'STAGE · React 19 Actions',
+        subtitle: '폼 + 낙관적 UI의 새 표준',
+        emoji: '🎬',
+        difficulty: 'hard',
+        hours: 4,
+        status: 'locked',
+        goals: [
+          'useActionState의 동작',
+          'useFormStatus로 pending UI',
+          'useOptimistic로 즉각 반응',
+          'Server Actions와의 연결',
+          '에러 처리 패턴',
+        ],
+        examples: [
+          '좋아요 버튼 (낙관적 UI)',
+          '로그인 폼 (pending 상태)',
+          'Server Action + 낙관적 UI 조합',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
       {
         id: 'bonus-app-router',
         title: 'BONUS · Next.js App Router',
@@ -335,7 +481,6 @@ export const sections: Section[] = [
         emoji: '⚡',
         difficulty: 'bonus',
         hours: 5,
-        bookRef: '책 11장 · p.715~774',
         status: 'locked',
         goals: [
           '서버 vs 클라이언트 컴포넌트',

--- a/src/data/stages.ts
+++ b/src/data/stages.ts
@@ -1,0 +1,362 @@
+export type Difficulty =
+  | 'tutorial'
+  | 'easy'
+  | 'medium'
+  | 'hard'
+  | 'boss'
+  | 'bonus'
+
+export type StageStatus = 'locked' | 'active' | 'completed'
+
+export type StageProgress = {
+  label: string
+  current: number
+  total: number
+}
+
+export type Stage = {
+  id: string
+  title: string
+  subtitle: string
+  emoji: string
+  difficulty: Difficulty
+  hours: number
+  bookRef: string
+  status: StageStatus
+  goals: string[]
+  examples: string[]
+  examplesLabel: string
+  progress?: StageProgress
+  highlight?: string
+  isBoss?: boolean
+}
+
+export type Section = {
+  id: string
+  label: string
+  sublabel: string
+  stages: Stage[]
+}
+
+export const sections: Section[] = [
+  {
+    id: 'basics',
+    label: '🟢 기본기 다지기',
+    sublabel: '리액트 렌더링의 기본 원리부터',
+    stages: [
+      {
+        id: 'stage-1-rendering',
+        title: 'STAGE 1 · 렌더링 기초',
+        subtitle: '리액트는 언제 다시 그려질까?',
+        emoji: '🎬',
+        difficulty: 'tutorial',
+        hours: 2,
+        bookRef: '책 2.4 ~ 2.5 · p.172~188',
+        status: 'locked',
+        goals: [
+          '리액트가 언제 다시 렌더링되는지',
+          '렌더링 프로세스 (Render → Commit)',
+          '메모이제이션이 왜 필요한지',
+          'React.StrictMode의 역할',
+        ],
+        examples: [
+          '리렌더 카운트 시각화',
+          '부모-자식 리렌더 전파',
+          'Render vs Commit',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+        progress: { label: '📝 블로그 · 퀴즈 3문제', current: 0, total: 3 },
+      },
+    ],
+  },
+  {
+    id: 'memoization',
+    label: '🟡 메모이제이션 3종 세트 ⭐',
+    sublabel: '지금 가장 궁금한 것 — useMemo, useCallback, React.memo',
+    stages: [
+      {
+        id: 'stage-2-usememo',
+        title: 'STAGE 2 · useMemo',
+        subtitle: '값을 기억하는 마법',
+        emoji: '🧙‍♂️',
+        difficulty: 'easy',
+        hours: 3,
+        bookRef: '책 3.1.3 · p.208~209',
+        status: 'active',
+        highlight: '⭐ 지금 시작!',
+        goals: [
+          'useMemo의 동작 원리',
+          '언제 써야 하는지 결정 트리',
+          '언제 쓰면 안 되는지',
+          '참조 동일성(referential equality)',
+          'useEffect 의존성과의 관계',
+        ],
+        examples: [
+          'Chaos Mode vs Calm Mode',
+          'Object Reference Trap',
+          '의존성 배열 실험실',
+          '❌ 잘못된 사용 안티패턴',
+        ],
+        examplesLabel: '만들 예제 (4개)',
+        progress: { label: '📝 블로그 · 퀴즈 5문제', current: 0, total: 4 },
+      },
+      {
+        id: 'stage-3-usecallback',
+        title: 'STAGE 3 · useCallback',
+        subtitle: '함수를 기억하는 마법',
+        emoji: '🎯',
+        difficulty: 'easy',
+        hours: 3,
+        bookRef: '책 3.1.4 · p.210~215',
+        status: 'locked',
+        goals: [
+          'useCallback과 useMemo의 관계',
+          '함수 참조 동일성이 중요한 이유',
+          'React.memo와의 시너지',
+          '커스텀 훅에서 useCallback 쓰는 이유',
+        ],
+        examples: [
+          '자식 컴포넌트 괴롭히기',
+          'useEffect 무한 루프',
+          '커스텀 훅 실험실',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+      {
+        id: 'stage-4-react-memo',
+        title: 'STAGE 4 · React.memo',
+        subtitle: '자식을 보호하는 방패',
+        emoji: '🛡️',
+        difficulty: 'medium',
+        hours: 4,
+        bookRef: '책 2.5 심화 · p.182~188',
+        status: 'locked',
+        goals: [
+          'React.memo 동작 원리 (shallow compare)',
+          '언제 효과적 / 언제 쓸모없는지',
+          '3종 세트의 조합 효과',
+          '객체/배열/함수 props의 함정',
+        ],
+        examples: [
+          '3종 세트 실험실',
+          '함정 예제: 리렌더 디버깅',
+          'Shallow Compare 시각화',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+    ],
+  },
+  {
+    id: 'core-hooks',
+    label: '🟠 핵심 훅 깊게 파기',
+    sublabel: '매일 쓰는 훅, 제대로 이해하기',
+    stages: [
+      {
+        id: 'stage-5-usestate',
+        title: 'STAGE 5 · useState 깊게',
+        subtitle: '얕게 쓰다 당한 버그들',
+        emoji: '📦',
+        difficulty: 'medium',
+        hours: 3,
+        bookRef: '책 3.1.1 · p.189~195',
+        status: 'locked',
+        goals: [
+          '배치 업데이트(batching)',
+          '게으른 초기화(Lazy Init)',
+          '함수형 업데이트 vs 값 업데이트',
+          'setState의 비동기 동작',
+        ],
+        examples: [
+          'Batch 실험',
+          '게으른 초기화 성능 비교',
+          'Stale Closure 트랩',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+      {
+        id: 'stage-6-useeffect',
+        title: 'STAGE 6 · useEffect 깊게',
+        subtitle: '안 써도 되는 경우가 더 많다',
+        emoji: '⚡',
+        difficulty: 'hard',
+        hours: 4,
+        bookRef: '책 3.1.2 · p.196~207',
+        status: 'locked',
+        goals: [
+          'useEffect는 생명주기 대체가 아니다',
+          '의존성 배열의 진짜 의미',
+          'Cleanup 함수의 역할',
+          'Race Condition 방지',
+          '언제 useEffect를 쓰지 말아야 하는지',
+        ],
+        examples: [
+          'Cleanup 실험실 (메모리 누수)',
+          'Race Condition 디버깅',
+          '의존성 배열 트러블슈팅',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+    ],
+  },
+  {
+    id: 'patterns',
+    label: '🔵 실전 패턴',
+    sublabel: '포트폴리오에 바로 쓸 수 있는 패턴들',
+    stages: [
+      {
+        id: 'stage-7-custom-hooks',
+        title: 'STAGE 7 · 커스텀 훅',
+        subtitle: '내 훅 만들기 실전',
+        emoji: '🔨',
+        difficulty: 'medium',
+        hours: 5,
+        bookRef: '책 3.2 · p.239~251',
+        status: 'locked',
+        goals: [
+          '커스텀 훅 설계 원칙',
+          'HOC vs 커스텀 훅',
+          '반환값 최적화 패턴',
+          '객체 반환 vs 배열 반환',
+        ],
+        examples: [
+          'useCopyToClipboard',
+          'useScrollReveal',
+          'useMediaQuery',
+          'useDebounce',
+          'useOnClickOutside',
+          'usePrevious',
+        ],
+        examplesLabel: '만들 훅 (6개)',
+      },
+      {
+        id: 'stage-8-useref',
+        title: 'STAGE 8 · useRef',
+        subtitle: 'DOM과 값의 두 얼굴',
+        emoji: '🎯',
+        difficulty: 'easy',
+        hours: 2,
+        bookRef: '책 3.1.5 · p.216~218',
+        status: 'locked',
+        goals: [
+          'useRef의 2가지 용도',
+          'useState와 뭐가 다른지',
+          'forwardRef 패턴',
+        ],
+        examples: [
+          'DOM 직접 조작 (포커스, 스크롤)',
+          'usePrevious 훅',
+          'forwardRef Input 컴포넌트',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+    ],
+  },
+  {
+    id: 'state',
+    label: '🟣 상태 관리',
+    sublabel: '규모가 커졌을 때 필요한 도구들',
+    stages: [
+      {
+        id: 'stage-9-usecontext',
+        title: 'STAGE 9 · useContext',
+        subtitle: '상태 관리 아니에요. 주입이에요.',
+        emoji: '🌐',
+        difficulty: 'medium',
+        hours: 3,
+        bookRef: '책 3.1.6 · p.219~224',
+        status: 'locked',
+        goals: [
+          'Context는 상태 관리 도구가 아니다',
+          'Context의 리렌더 문제',
+          '언제 Context / 언제 라이브러리',
+        ],
+        examples: ['테마 토글 (다크모드)', 'Context 리렌더 실험'],
+        examplesLabel: '만들 예제 (2개)',
+      },
+      {
+        id: 'stage-10-usereducer',
+        title: 'STAGE 10 · useReducer',
+        subtitle: '복잡한 상태는 나눠 정복하라',
+        emoji: '⚙️',
+        difficulty: 'medium',
+        hours: 3,
+        bookRef: '책 3.1.7 · p.225~228',
+        status: 'locked',
+        goals: [
+          'useState vs useReducer 선택 기준',
+          '복잡한 상태 로직 관리',
+          'dispatch 패턴',
+        ],
+        examples: ['Todo 리스트 (두 버전 비교)', '폼 상태 관리'],
+        examplesLabel: '만들 예제 (2개)',
+      },
+    ],
+  },
+  {
+    id: 'boss',
+    label: '👑 최종 보스전',
+    sublabel: '실전 버그를 디버깅하며 배운 것 총정리',
+    stages: [
+      {
+        id: 'boss-rendering',
+        title: 'BOSS · 렌더링 최적화 보스전',
+        subtitle: '실전 프로젝트 버그를 고쳐라',
+        emoji: '👑',
+        difficulty: 'boss',
+        hours: 5,
+        bookRef: '종합 · 실전 디버깅',
+        status: 'locked',
+        isBoss: true,
+        goals: [
+          'React DevTools Profiler 활용',
+          'Lighthouse 점수 개선',
+          'Web Vitals 이해',
+          '실전 디버깅 워크플로우',
+        ],
+        examples: [
+          'Mission 1: 1000개 리스트 최적화',
+          'Mission 2: 느린 검색창 고치기',
+          'Mission 3: 스크롤 프레임 드랍',
+          'Mission 4: 무한 렌더 루프 잡기',
+        ],
+        examplesLabel: '보스 미션 (4개)',
+      },
+    ],
+  },
+  {
+    id: 'bonus',
+    label: '🎁 BONUS · Next.js 16 특별판',
+    sublabel: '나래님이 쓰고 있는 스택의 최신 기능',
+    stages: [
+      {
+        id: 'bonus-app-router',
+        title: 'BONUS · Next.js App Router',
+        subtitle: '서버 컴포넌트의 신세계',
+        emoji: '⚡',
+        difficulty: 'bonus',
+        hours: 5,
+        bookRef: '책 11장 · p.715~774',
+        status: 'locked',
+        goals: [
+          '서버 vs 클라이언트 컴포넌트',
+          "'use client' 경계 설정",
+          'Server Actions',
+          '캐싱 전략 (fetch + revalidate)',
+        ],
+        examples: [
+          'Client vs Server 비교',
+          'Streaming + Suspense',
+          'Server Actions로 폼',
+        ],
+        examplesLabel: '만들 예제 (3개)',
+      },
+    ],
+  },
+]
+
+export const allStages: Stage[] = sections.flatMap((s) => s.stages)
+export const totalStages = allStages.length
+export const totalExamples = allStages.reduce(
+  (sum, s) => sum + s.examples.length,
+  0
+)


### PR DESCRIPTION
## 작업 내용

HTML 목업을 Next.js + Tailwind v4로 구현한 React Quest 대시보드 랜딩 페이지.
게임 스타일로 12 스테이지 + 보스전 + Modern React 19 섹션을 시각화.

## 변경 사항 (커밋 2개)

**1. 초기 구현 (`01a1466`)**
- [x] 데이터 스키마: `src/data/stages.ts`, `src/data/achievements.ts`
- [x] Quest 컴포넌트 5종: Dashboard, Legend, StageCard (+ variants), Achievement, QuestSection
- [x] 폰트: Pretendard (jsdelivr CDN via `<link>`) + JetBrains Mono (`next/font/google`)
- [x] theme.css: Quest 전용 색상 토큰 (success/warning/purple/danger + difficulty 뱃지) + `quest-bounce` 애니메이션
- [x] Footer: 연결 자산(포트폴리오 / 블로그 / GitHub) 링크 버튼 스타일
- [x] `page.tsx` 전면 교체

**2. 트렌디 스테이지 7종 추가 + 책 레퍼런스 제거 (`7c2100c`)**
- [x] React Compiler (🟡 메모이제이션)
- [x] Error Boundary (🟠 핵심 훅)
- [x] 접근성 a11y (🔵 실전 패턴)
- [x] 테스트 RTL + Vitest (🔵 실전 패턴)
- [x] TanStack Query (🟣 상태 관리)
- [x] React 19 Actions (🔮 Modern)
- [x] Suspense + use (🔮 Modern)
- [x] `Stage` 타입에서 `bookRef` 제거 → `StageCard`에서 `📖 책...` 영역 삭제
- [x] Dashboard 헤더: "책: 모던 리액트 Deep Dive" → "프론트엔드 디자이너의 React 정복 퀘스트"

## 변경 타입

- [x] feat (새 기능)
- [ ] fix (버그 수정)
- [ ] chore (설정 변경)
- [ ] refactor (리팩토링)

## 스크린샷

로컬 dev (`npm run dev`) → http://localhost:3000 에서 확인 가능.

## 관련 이슈

closes #2

## 셀프 체크리스트

- [x] 코드 동작 확인 (`npm run build` + `npm run lint` + `curl` 렌더 테스트 통과)
- [x] 콘솔 에러 없음