### PR TITLE
✨ Feature: useMemo 인터랙티브 놀이터 + 스테이지 상세 라우트

### DIFF
--- a/src/app/stages/[id]/page.tsx
+++ b/src/app/stages/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation'
+import { allStages } from '@/data/stages'
+import StageDetail from '@/components/stages/StageDetail'
+
+export function generateStaticParams() {
+  return allStages.map((s) => ({ id: s.id }))
+}
+
+type PageProps = {
+  params: Promise<{ id: string }>
+}
+
+export default async function StagePage({ params }: PageProps) {
+  const { id } = await params
+  const stage = allStages.find((s) => s.id === id)
+  if (!stage) notFound()
+  return <StageDetail stage={stage} />
+}

--- a/src/components/playgrounds/usememo/ChaosCalm.tsx
+++ b/src/components/playgrounds/usememo/ChaosCalm.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { cn } from '@/lib/cn'
+
+const CARDS = 40
+const ITERATIONS = 60_000
+
+function heavy(seed: number) {
+  let result = 0
+  for (let i = 1; i <= ITERATIONS; i += 1) {
+    result += Math.sqrt(i * seed) * Math.sin(i)
+  }
+  return result.toFixed(2)
+}
+
+function ChaosCard({ seed, bump }: { seed: number; bump: number }) {
+  const value = heavy(seed + bump * 0)
+  return (
+    <div className='rounded-lg bg-white px-2 py-2 text-center font-mono text-[10px] shadow-sm ring-1 ring-gray-100'>
+      #{seed}
+      <div className='truncate text-gray-400'>{value}</div>
+    </div>
+  )
+}
+
+function CalmCard({ seed }: { seed: number }) {
+  const value = useMemo(() => heavy(seed), [seed])
+  return (
+    <div className='rounded-lg bg-white px-2 py-2 text-center font-mono text-[10px] shadow-sm ring-1 ring-gray-100'>
+      #{seed}
+      <div className='truncate text-gray-400'>{value}</div>
+    </div>
+  )
+}
+
+export default function ChaosCalm() {
+  const [mode, setMode] = useState<'chaos' | 'calm'>('chaos')
+  const [bump, setBump] = useState(0)
+  const [lastMs, setLastMs] = useState<number | null>(null)
+  const [renders, setRenders] = useState(0)
+
+  const seeds = useMemo(
+    () => Array.from({ length: CARDS }, (_, i) => i + 1),
+    []
+  )
+
+  const handleBump = () => {
+    const start = performance.now()
+    setBump((b) => b + 1)
+    setRenders((r) => r + 1)
+    // 실제 렌더 이후 측정. rAF로 다음 프레임에 종료 시점 기록.
+    requestAnimationFrame(() => {
+      setLastMs(Math.round(performance.now() - start))
+    })
+  }
+
+  const handleReset = () => {
+    setBump(0)
+    setRenders(0)
+    setLastMs(null)
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <div className='flex rounded-full bg-white p-1 shadow-sm ring-1 ring-gray-200'>
+          <ModeButton
+            active={mode === 'chaos'}
+            onClick={() => setMode('chaos')}
+            label='🔥 Chaos'
+            tone='danger'
+          />
+          <ModeButton
+            active={mode === 'calm'}
+            onClick={() => setMode('calm')}
+            label='❄️ Calm'
+            tone='success'
+          />
+        </div>
+        <button
+          type='button'
+          onClick={handleBump}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-[#ec4b36]'
+        >
+          ➕ 무관한 카운터 +1
+        </button>
+        <button
+          type='button'
+          onClick={handleReset}
+          className='rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-600 hover:border-gray-300'
+        >
+          ↺ 리셋
+        </button>
+      </div>
+
+      <div className='mb-4 grid grid-cols-3 gap-3 rounded-xl bg-white p-4 shadow-sm'>
+        <Stat label='🔁 렌더 횟수' value={renders.toString()} />
+        <Stat
+          label='⏱ 마지막 렌더'
+          value={lastMs === null ? '—' : `${lastMs}ms`}
+        />
+        <Stat
+          label='모드'
+          value={mode === 'chaos' ? '🔥 매 렌더 계산' : '❄️ useMemo 캐시'}
+        />
+      </div>
+
+      <p className='mb-3 text-sm text-gray-600'>
+        {mode === 'chaos' ? (
+          <>
+            🔥 <b>Chaos Mode</b> — 카드가 40개, 각자가 매 렌더마다{' '}
+            <span className='font-mono'>{ITERATIONS.toLocaleString()}</span>번
+            계산해. 카운터 버튼 눌러봐. 느려지는 게 느껴지지?
+          </>
+        ) : (
+          <>
+            ❄️ <b>Calm Mode</b> — 같은 카드 40개, 근데{' '}
+            <span className='font-mono'>useMemo</span>로 감싸서 seed가 안 바뀌면
+            재계산 안 해. 카운터 눌러도 계산은 건너뜀.
+          </>
+        )}
+      </p>
+
+      <div
+        className={cn(
+          'grid grid-cols-5 gap-2 rounded-xl p-3 transition-colors sm:grid-cols-8',
+          mode === 'chaos'
+            ? 'bg-gradient-to-br from-red-50 to-orange-50'
+            : 'bg-gradient-to-br from-sky-50 to-blue-50'
+        )}
+      >
+        {mode === 'chaos'
+          ? seeds.map((s) => <ChaosCard key={s} seed={s} bump={bump} />)
+          : seeds.map((s) => <CalmCard key={s} seed={s} />)}
+      </div>
+    </div>
+  )
+}
+
+function ModeButton({
+  active,
+  onClick,
+  label,
+  tone,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+  tone: 'danger' | 'success'
+}) {
+  const activeBg = tone === 'danger' ? 'bg-red-500' : 'bg-emerald-500'
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(
+        'rounded-full px-4 py-1.5 text-sm font-bold transition',
+        active
+          ? `${activeBg} text-white shadow`
+          : 'text-gray-500 hover:text-gray-800'
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        {label}
+      </div>
+      <div className='mt-0.5 font-mono text-sm font-bold'>{value}</div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usememo/ObjectReferenceTrap.tsx
+++ b/src/components/playgrounds/usememo/ObjectReferenceTrap.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { cn } from '@/lib/cn'
+
+function TrapChild({ config }: { config: { limit: number } }) {
+  const [runs, setRuns] = useState(0)
+
+  useEffect(() => {
+    // 의도된 사이드 이펙트: 참조가 바뀔 때마다 effect 실행 횟수를 카운트.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRuns((r) => r + 1)
+  }, [config])
+
+  return (
+    <div className='rounded-lg bg-white p-4 ring-1 ring-gray-200'>
+      <div className='text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+        🧪 자식의 useEffect 실행 횟수
+      </div>
+      <div className='mt-1 font-mono text-3xl font-extrabold'>{runs}</div>
+      <div className='mt-1 font-mono text-[11px] text-gray-400'>
+        deps: [config] · limit: {config.limit}
+      </div>
+    </div>
+  )
+}
+
+export default function ObjectReferenceTrap() {
+  const [tick, setTick] = useState(0)
+  const [memoize, setMemoize] = useState(false)
+
+  // 부모 렌더 때마다 새 객체. 참조가 바뀌어서 자식 effect 매번 실행.
+  const fresh = { limit: 10 }
+  // 메모이즈된 객체. 참조 안정.
+  const stable = useMemo(() => ({ limit: 10 }), [])
+
+  const config = memoize ? stable : fresh
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setTick((t) => t + 1)}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🎲 부모 리렌더 {tick}
+        </button>
+        <button
+          type='button'
+          onClick={() => setMemoize((m) => !m)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            memoize
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          {memoize ? '✅ useMemo 켜짐' : '⬜️ useMemo 꺼짐'}
+        </button>
+      </div>
+
+      <div className='mb-4 grid gap-3 sm:grid-cols-2'>
+        <TrapChild config={config} />
+        <div className='rounded-lg bg-white p-4 text-sm ring-1 ring-gray-200'>
+          <div className='text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+            💡 무슨 일이 벌어지고 있는지
+          </div>
+          <p className='mt-2 text-gray-700'>
+            {memoize ? (
+              <>
+                <span className='text-emerald-600'>참조 안정</span>: 부모가 몇
+                번 리렌더되든 <code>config</code> 참조는 그대로. 자식의{' '}
+                <code>useEffect</code>는 <b>한 번만</b> 실행.
+              </>
+            ) : (
+              <>
+                <span className='text-red-600'>참조 새로 생성</span>: 리렌더마다{' '}
+                <code>{`{ limit: 10 }`}</code>이 새 객체. 자식의{' '}
+                <code>useEffect</code>가 <b>매 리렌더마다</b> 다시 돔.
+              </>
+            )}
+          </p>
+        </div>
+      </div>
+
+      <pre className='overflow-x-auto rounded-lg bg-gray-900 p-4 font-mono text-[12px] text-gray-100'>
+        {memoize
+          ? `// 부모
+const stable = useMemo(() => ({ limit: 10 }), [])
+<TrapChild config={stable} />
+
+// 자식
+useEffect(() => { ... }, [config])  // ✅ 마운트 1회만`
+          : `// 부모
+const fresh = { limit: 10 }  // ❌ 렌더마다 새 객체
+<TrapChild config={fresh} />
+
+// 자식
+useEffect(() => { ... }, [config])  // 🔁 매 리렌더마다 실행`}
+      </pre>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usememo/index.tsx
+++ b/src/components/playgrounds/usememo/index.tsx
@@ -1,0 +1,27 @@
+import ChaosCalm from './ChaosCalm'
+import ObjectReferenceTrap from './ObjectReferenceTrap'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseMemoPlayground() {
+  return (
+    <div className='flex flex-col gap-10'>
+      <PlaygroundSection
+        index='A'
+        emoji='🎢'
+        title='Chaos Mode vs Calm Mode'
+        description='40개 카드가 매 렌더마다 무거운 계산을 돌린다. useMemo로 감싸면 seed가 그대로일 때 건너뛴다. 카운터 버튼을 눌러 차이를 몸으로 느껴보자.'
+      >
+        <ChaosCalm />
+      </PlaygroundSection>
+
+      <PlaygroundSection
+        index='B'
+        emoji='🪤'
+        title='Object Reference Trap'
+        description='객체·배열·함수는 매 렌더마다 새 참조. 자식이 useEffect deps로 받으면 매번 다시 실행된다. useMemo로 참조를 얼려서 뭐가 달라지는지 직접 확인.'
+      >
+        <ObjectReferenceTrap />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -1,4 +1,6 @@
+import Link from 'next/link'
 import type { Stage } from '@/data/stages'
+import { hasPlayground } from '@/data/playgrounds'
 import { cn } from '@/lib/cn'
 import {
   difficultyBadge,
@@ -17,11 +19,15 @@ export default function StageCard({ stage }: StageCardProps) {
       : stage.status === 'active'
         ? '🔓'
         : '🔒'
+  const playgroundReady = hasPlayground(stage.id)
 
   return (
-    <article
+    <Link
+      href={`/stages/${stage.id}`}
+      aria-label={`${stage.title} 상세로 이동`}
       className={cn(
         stageCardVariants({ status: stage.status, boss: stage.isBoss }),
+        'block focus-visible:ring-2 focus-visible:ring-[#ff5e48] focus-visible:outline-none',
         stage.status === 'locked' && 'hover:translate-y-0 hover:shadow-none'
       )}
     >
@@ -49,6 +55,11 @@ export default function StageCard({ stage }: StageCardProps) {
                 </span>
               )}
               <span className='text-xs text-gray-500'>⏱ {stage.hours}시간</span>
+              {playgroundReady && (
+                <span className='inline-flex items-center gap-1 rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-bold text-white'>
+                  🕹️ 플레이 가능
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -80,7 +91,7 @@ export default function StageCard({ stage }: StageCardProps) {
           </div>
         </footer>
       )}
-    </article>
+    </Link>
   )
 }
 

--- a/src/components/stages/PlaygroundPlaceholder.tsx
+++ b/src/components/stages/PlaygroundPlaceholder.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+type Props = {
+  stageTitle: string
+}
+
+export default function PlaygroundPlaceholder({ stageTitle }: Props) {
+  return (
+    <div className='rounded-2xl border-2 border-dashed border-gray-200 bg-white/50 p-10 text-center'>
+      <div className='mb-3 text-5xl'>🛠️</div>
+      <h3 className='mb-2 text-xl font-extrabold'>놀이기구 제작 중</h3>
+      <p className='mx-auto max-w-md text-sm text-gray-500'>
+        <b>{stageTitle}</b>의 인터랙티브 데모는 다음 스프린트에 들어와. 일단
+        위의 학습 목표 + 만들 예제 리스트부터 훑어봐.
+      </p>
+      <Link
+        href='/'
+        className='mt-5 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:border-[#ff5e48] hover:text-[#ff5e48]'
+      >
+        ← 로드맵으로 돌아가기
+      </Link>
+    </div>
+  )
+}

--- a/src/components/stages/PlaygroundSection.tsx
+++ b/src/components/stages/PlaygroundSection.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from 'react'
+
+type Props = {
+  index: string
+  emoji: string
+  title: string
+  description: string
+  children: ReactNode
+}
+
+export default function PlaygroundSection({
+  index,
+  emoji,
+  title,
+  description,
+  children,
+}: Props) {
+  return (
+    <section>
+      <header className='mb-3 flex items-center gap-3'>
+        <span className='flex h-9 w-9 items-center justify-center rounded-full bg-[#ff5e48] font-mono text-sm font-bold text-white shadow-sm'>
+          {index}
+        </span>
+        <div>
+          <h3 className='text-lg font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h3>
+          <p className='text-sm text-gray-600'>{description}</p>
+        </div>
+      </header>
+      {children}
+    </section>
+  )
+}

--- a/src/components/stages/StageDetail.tsx
+++ b/src/components/stages/StageDetail.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+import { categoryMeta, type Stage } from '@/data/stages'
+import { playgrounds } from '@/data/playgrounds'
+import {
+  difficultyBadge,
+  difficultyLabel,
+} from '@/components/quest/StageCard.variants'
+import PlaygroundPlaceholder from './PlaygroundPlaceholder'
+
+type Props = {
+  stage: Stage
+}
+
+export default function StageDetail({ stage }: Props) {
+  const category = categoryMeta.find((c) => c.id === stage.category)
+  const Playground = playgrounds[stage.id]
+
+  return (
+    <div className='mx-auto max-w-240 px-6 py-10'>
+      <nav className='mb-6 flex flex-wrap items-center gap-1 text-sm text-gray-500'>
+        <Link href='/' className='hover:text-[#ff5e48]'>
+          🎮 Quest
+        </Link>
+        <span>/</span>
+        <Link href={`/?tab=${stage.category}`} className='hover:text-[#ff5e48]'>
+          {category?.emoji} {category?.label}
+        </Link>
+        <span>/</span>
+        <span className='font-semibold text-gray-800'>{stage.title}</span>
+      </nav>
+
+      <header className='mb-8'>
+        <div className='mb-3 flex items-center gap-3'>
+          <span className='text-5xl'>{stage.emoji}</span>
+          <div>
+            <h1 className='text-3xl font-extrabold tracking-tight sm:text-4xl'>
+              {stage.title}
+            </h1>
+            <p className='mt-1 text-gray-500'>{stage.subtitle}</p>
+          </div>
+        </div>
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className={difficultyBadge({ difficulty: stage.difficulty })}>
+            {difficultyLabel[stage.difficulty]}
+          </span>
+          {stage.highlight && (
+            <span className='text-xs font-bold text-[#ff5e48]'>
+              {stage.highlight}
+            </span>
+          )}
+          <span className='text-xs text-gray-500'>⏱ {stage.hours}시간</span>
+          {stage.status === 'locked' && (
+            <span className='ml-2 text-xs font-bold text-gray-500'>
+              🔒 잠김 — 미리보기
+            </span>
+          )}
+        </div>
+      </header>
+
+      <section className='mb-10 grid gap-5 rounded-2xl bg-white p-6 ring-1 ring-gray-100 md:grid-cols-2'>
+        <Bullets title='🎯 학습 목표' items={stage.goals} />
+        <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
+      </section>
+
+      <section>
+        <div className='mb-4 flex items-end justify-between'>
+          <h2 className='text-xl font-extrabold'>🕹️ 놀이기구</h2>
+          {Playground && (
+            <span className='text-xs text-gray-500'>
+              아래에서 직접 눌러보고 망가뜨려봐
+            </span>
+          )}
+        </div>
+        {Playground ? (
+          <Playground />
+        ) : (
+          <PlaygroundPlaceholder stageTitle={stage.title} />
+        )}
+      </section>
+
+      <div className='mt-10 flex justify-center'>
+        <Link
+          href={`/?tab=${stage.category}`}
+          className='inline-flex items-center gap-2 rounded-full border-2 border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 hover:border-[#ff5e48] hover:text-[#ff5e48]'
+        >
+          ← {category?.emoji} {category?.label} 로 돌아가기
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+function Bullets({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <div className='mb-2 text-xs font-bold tracking-[0.08em] text-gray-500 uppercase'>
+        {title}
+      </div>
+      <ul className='flex flex-col gap-1.5'>
+        {items.map((text) => (
+          <li
+            key={text}
+            className='flex items-start gap-2 text-sm leading-snug'
+          >
+            <span className='shrink-0 font-mono text-gray-400'>▸</span>
+            <span>{text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/data/playgrounds.ts
+++ b/src/data/playgrounds.ts
@@ -1,0 +1,9 @@
+import type { ComponentType } from 'react'
+import UseMemoPlayground from '@/components/playgrounds/usememo'
+
+export const playgrounds: Record<string, ComponentType> = {
+  'stage-2-usememo': UseMemoPlayground,
+}
+
+export const hasPlayground = (stageId: string): boolean =>
+  stageId in playgrounds


### PR DESCRIPTION
closes #7

## 변경 사항

- 동적 라우트 `/stages/[id]` 추가, `generateStaticParams`로 28 스테이지 정적 생성
- `StageDetail` 레이아웃: 브레드크럼 + 학습 목표/예제 카드 + 놀이기구 영역
- `PlaygroundPlaceholder`: 미구현 스테이지용 "제작 중" UI
- `PlaygroundSection`: 공통 놀이기구 헤더 (인덱스·이모지·설명)
- `playgrounds` 레지스트리: stageId → 컴포넌트 매핑
- `StageCard` 전체를 Link로 전환, 🕹️ 플레이 가능 배지 표시

## useMemo 놀이기구 2종

**A. Chaos Mode vs Calm Mode**
- 40개 카드 × 60k 계산. 무관한 카운터 버튼으로 re-render 유도
- useMemo 유무 차이를 ms 단위로 체감

**B. Object Reference Trap**
- useMemo 토글로 객체 참조 안정 vs 매 렌더 새 참조 비교
- 자식의 useEffect 실행 횟수로 참조 동일성 이슈를 시각화

## 다음 PR

Dependency Lab + Anti-pattern 놀이기구, 그리고 코드 예시·학습 목표 시각화 강화 (사용자 피드백)
