### PR TITLE
✨ Feature: useMemo 스테이지 초보자 학습 경험 강화

### DIFF
--- a/src/components/playgrounds/usememo/ChaosCalm.tsx
+++ b/src/components/playgrounds/usememo/ChaosCalm.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
 
 const CARDS = 40
 const ITERATIONS = 60_000
@@ -14,8 +15,9 @@ function heavy(seed: number) {
   return result.toFixed(2)
 }
 
-function ChaosCard({ seed, bump }: { seed: number; bump: number }) {
-  const value = heavy(seed + bump * 0)
+function ChaosCard({ seed }: { seed: number }) {
+  // 부모가 리렌더되면 이 컴포넌트도 리렌더되고, 이 줄이 또 실행됨 (메모 없음)
+  const value = heavy(seed)
   return (
     <div className='rounded-lg bg-white px-2 py-2 text-center font-mono text-[10px] shadow-sm ring-1 ring-gray-100'>
       #{seed}
@@ -36,7 +38,6 @@ function CalmCard({ seed }: { seed: number }) {
 
 export default function ChaosCalm() {
   const [mode, setMode] = useState<'chaos' | 'calm'>('chaos')
-  const [bump, setBump] = useState(0)
   const [lastMs, setLastMs] = useState<number | null>(null)
   const [renders, setRenders] = useState(0)
 
@@ -47,16 +48,13 @@ export default function ChaosCalm() {
 
   const handleBump = () => {
     const start = performance.now()
-    setBump((b) => b + 1)
-    setRenders((r) => r + 1)
-    // 실제 렌더 이후 측정. rAF로 다음 프레임에 종료 시점 기록.
+    setRenders((r) => r + 1) // state 변경 → 부모 리렌더 → 자식들 전부 다시 실행
     requestAnimationFrame(() => {
       setLastMs(Math.round(performance.now() - start))
     })
   }
 
   const handleReset = () => {
-    setBump(0)
     setRenders(0)
     setLastMs(null)
   }
@@ -106,33 +104,95 @@ export default function ChaosCalm() {
         />
       </div>
 
-      <p className='mb-3 text-sm text-gray-600'>
+      <div className='mb-3 rounded-lg bg-white p-4 ring-1 ring-gray-100'>
         {mode === 'chaos' ? (
-          <>
-            🔥 <b>Chaos Mode</b> — 카드가 40개, 각자가 매 렌더마다{' '}
-            <span className='font-mono'>{ITERATIONS.toLocaleString()}</span>번
-            계산해. 카운터 버튼 눌러봐. 느려지는 게 느껴지지?
-          </>
+          <div className='space-y-1.5 text-sm text-gray-700'>
+            <p>
+              🎡 40개 카드가 각자 <b>무거운 계산</b>(
+              <span className='font-mono'>{ITERATIONS.toLocaleString()}</span>번
+              루프)을 돌려. <b>카운터 버튼</b>을 누르면 화면이 다시 그려지고
+              (리렌더), 모든 카드가 <b>처음부터 다시</b> 계산해.
+            </p>
+            <p className='rounded bg-amber-50 p-2 text-xs text-amber-900'>
+              🔍 <b>관찰 포인트</b>: 버튼 누를 때마다 &quot;마지막 렌더&quot;
+              ms가 크게 찍혀. 100ms 넘으면 눈에 보이는 렉(끊김)이야.
+            </p>
+          </div>
         ) : (
-          <>
-            ❄️ <b>Calm Mode</b> — 같은 카드 40개, 근데{' '}
-            <span className='font-mono'>useMemo</span>로 감싸서 seed가 안 바뀌면
-            재계산 안 해. 카운터 눌러도 계산은 건너뜀.
-          </>
+          <div className='space-y-1.5 text-sm text-gray-700'>
+            <p>
+              ❄️ 같은 40개 카드지만, 이번엔{' '}
+              <code className='bg-gray-100 px-1 font-mono'>useMemo</code>로
+              결과를 <b>종이에 적어뒀어</b>. 입력(seed)이 안 바뀌면 리액트가
+              계산을 건너뛰고 저장해둔 답 그대로 써.
+            </p>
+            <p className='rounded bg-emerald-50 p-2 text-xs text-emerald-900'>
+              🔍 <b>관찰 포인트</b>: 카운터를 아무리 눌러도 &quot;마지막
+              렌더&quot; ms가 거의 0. Chaos와 바꿔가며 숫자 비교해봐.
+            </p>
+          </div>
         )}
-      </p>
+      </div>
 
       <div
         className={cn(
-          'grid grid-cols-5 gap-2 rounded-xl p-3 transition-colors sm:grid-cols-8',
+          'mb-4 grid grid-cols-5 gap-2 rounded-xl p-3 transition-colors sm:grid-cols-8',
           mode === 'chaos'
-            ? 'bg-gradient-to-br from-red-50 to-orange-50'
-            : 'bg-gradient-to-br from-sky-50 to-blue-50'
+            ? 'bg-linear-to-br from-red-50 to-orange-50'
+            : 'bg-linear-to-br from-sky-50 to-blue-50'
         )}
       >
         {mode === 'chaos'
-          ? seeds.map((s) => <ChaosCard key={s} seed={s} bump={bump} />)
+          ? seeds.map((s) => <ChaosCard key={s} seed={s} />)
           : seeds.map((s) => <CalmCard key={s} seed={s} />)}
+      </div>
+
+      <div>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          ✍️ 코드로 비교하면
+        </div>
+        <BeforeAfter
+          before={{
+            label: 'ChaosCard.tsx',
+            code: `function ChaosCard({ seed }: { seed: number }) {
+  // 화면이 다시 그려질 때마다 heavy()를 처음부터 또 실행
+  const value = heavy(seed)
+  return <div>{value}</div>
+}`,
+            takeaway:
+              '부모가 리렌더될 때마다 40개 카드 전부가 처음부터 계산 → ms가 급등',
+          }}
+          after={{
+            label: 'CalmCard.tsx',
+            code: `function CalmCard({ seed }: { seed: number }) {
+  // seed가 같으면 지난번 결과를 그대로 돌려받음
+  const value = useMemo(() => heavy(seed), [seed])
+  return <div>{value}</div>
+}`,
+            takeaway:
+              'seed가 안 바뀌면 heavy() 호출이 건너뛰어짐 → ms ≈ 0 유지',
+          }}
+        />
+      </div>
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 왜 이걸 쓰는가 · 언제 쓰는가
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 <b>왜</b>: 무거운 계산 결과를 <b>종이에 적어두고 재사용</b>해서,
+            화면이 자주 다시 그려져도 브라우저가 같은 일을 반복하지 않게 함.
+          </li>
+          <li>
+            🕰️ <b>언제</b>: 이 놀이기구처럼 <b>실제로 느린 연산</b>이 있을 때.
+            단순 덧셈·문자열 조립 같은 건 감쌀 필요 없음.
+          </li>
+          <li>
+            ⚠️ <b>주의</b>: <code>useMemo</code>도 공짜가 아니야. 측정 없이
+            남발하면 오히려 코드가 복잡해지고 느려질 수 있어.
+          </li>
+        </ul>
       </div>
     </div>
   )

--- a/src/components/playgrounds/usememo/GoalViz.tsx
+++ b/src/components/playgrounds/usememo/GoalViz.tsx
@@ -1,0 +1,197 @@
+import { ReactNode } from 'react'
+
+export default function UseMemoGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          공식을 외우지 말고, 버튼 먼저 눌러보고 직관부터 잡자.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        {/* 1 */}
+        <GoalCard
+          index='1'
+          emoji='🧠'
+          title='useMemo가 하는 일'
+          hook='계산기 다시 두드리기 vs 종이에 답 적어두기'
+        >
+          <p>
+            리액트는 화면이 바뀔 때마다 컴포넌트 함수를{' '}
+            <b>처음부터 다시 실행</b>해 (= 리렌더). 그 안에 무거운 계산이 있으면
+            매번 또 돌려야 해서 느려질 수 있어.
+          </p>
+          <p>
+            <code className='bg-gray-100 px-1'>useMemo</code>는 &quot;입력이
+            그대로면 지난번 답 그대로 줘&quot;라고 약속하는 장치야. 쉽게 말해
+            <b>결과를 종이에 적어두고 다음번에 재사용</b>(메모이제이션)하는
+            거야.
+          </p>
+          <div className='mt-3 flex items-center gap-2 rounded-lg bg-white p-3 font-mono text-xs ring-1 ring-gray-200'>
+            <span className='rounded bg-gray-100 px-2 py-1'>입력 [a, b]</span>
+            <span>→</span>
+            <span className='rounded bg-amber-100 px-2 py-1'>🧮 계산</span>
+            <span>→</span>
+            <span className='rounded bg-emerald-100 px-2 py-1'>💾 저장</span>
+          </div>
+          <p className='mt-2 text-[11px] text-gray-500'>
+            다음 렌더에서 입력이 같으면 🧮 단계 건너뛰고 💾에서 바로 꺼내 씀
+          </p>
+        </GoalCard>
+
+        {/* 2 */}
+        <GoalCard
+          index='2'
+          emoji='🌲'
+          title='언제 써야 할까?'
+          hook='감으로 쓰지 말고, 이유가 있을 때만'
+        >
+          <p className='text-[13px]'>
+            다음 세 가지 중 하나라도 해당하면 useMemo 후보야.
+          </p>
+          <ul className='mt-2 space-y-1.5 text-[13px]'>
+            <li>
+              <b>Q1.</b> 실제로 측정했을 때 느린 계산인가?
+            </li>
+            <li>
+              <b>Q2.</b> 자식이나 훅에 넘기는{' '}
+              <b>객체·배열·함수를 안정적으로 유지</b>해야 하나?
+            </li>
+            <li>
+              <b>Q3.</b> 이 값이 <code>useEffect</code>의 주시 목록(deps)에
+              들어가나?
+            </li>
+          </ul>
+          <p className='mt-3 rounded-lg bg-emerald-50 p-3 text-[13px] text-emerald-900'>
+            ✅ 하나라도 <b>YES</b>면 useMemo 고려
+          </p>
+          <p className='mt-2 rounded-lg bg-red-50 p-3 text-[13px] text-red-900'>
+            ❌ 전부 <b>NO</b>면 그냥 계산해 — 오히려 방해가 됨
+          </p>
+        </GoalCard>
+
+        {/* 3 */}
+        <GoalCard
+          index='3'
+          emoji='🚫'
+          title='쓰면 안 되는 경우'
+          hook='쉬운 일을 감싸면 오히려 느려진다'
+        >
+          <p>
+            useMemo 자체도 <b>비교하고 저장하는 비용</b>이 있어. 2+2처럼
+            순식간에 끝나는 계산을 감싸면 브라우저가 일을 더 많이 하게 돼.
+          </p>
+          <p>
+            또 주시 목록에 매번 새로 만들어지는 값을 넣으면 저장한 답이{' '}
+            <b>한 번도 재사용되지 않아</b>. 그럴 땐 감싸지 않느니만 못해.
+          </p>
+          <pre className='rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// 이런 건 감싸지 마세요
+const total = useMemo(() => a + b, [a, b])`}
+          </pre>
+        </GoalCard>
+
+        {/* 4 */}
+        <GoalCard
+          index='4'
+          emoji='🔗'
+          title='같은 물건인지 확인 (참조 동일성)'
+          hook='내용이 같아도 "같은 물건"은 아닐 수 있다'
+        >
+          <p>
+            자바스크립트에서 <code>{`{a: 1} === {a: 1}`}</code>은 결과가{' '}
+            <b>false</b>야. 리액트는 props나 주시 목록을 비교할 때 이 규칙을 써.
+          </p>
+          <div className='mt-3 grid grid-cols-2 gap-2 text-center text-xs'>
+            <div className='rounded-lg bg-red-50 p-3'>
+              <div className='font-mono text-gray-700'>{`{ limit: 10 }`}</div>
+              <div className='mt-1 text-[11px] text-red-600'>
+                첫 렌더의 객체
+              </div>
+            </div>
+            <div className='rounded-lg bg-red-50 p-3'>
+              <div className='font-mono text-gray-700'>{`{ limit: 10 }`}</div>
+              <div className='mt-1 text-[11px] text-red-600'>
+                두 번째 렌더의 객체
+              </div>
+            </div>
+          </div>
+          <p className='mt-2 text-center font-mono text-sm text-red-600'>
+            === <b>false</b>
+          </p>
+          <p className='mt-2'>
+            <code className='bg-gray-100 px-1'>useMemo</code>로 감싸면 렌더가
+            반복돼도 <b>같은 물건(같은 참조)</b>을 돌려받아서 하위가 &quot;안
+            바뀌었네&quot; 하고 넘어갈 수 있어.
+          </p>
+        </GoalCard>
+
+        {/* 5 */}
+        <GoalCard
+          index='5'
+          emoji='🪢'
+          title='useEffect와의 찰떡 관계'
+          hook='주시 목록에 객체를 넣으면 참조로 비교된다'
+        >
+          <p>
+            <code className='bg-gray-100 px-1'>useEffect(fn, [config])</code>는{' '}
+            <b>주시 목록(deps) 안의 값이 바뀔 때만</b> 실행돼. 근데 그 값이 매
+            렌더마다 새로 만들어진 객체면? 실제로 안 바뀌었어도 리액트는
+            &quot;바뀐 것 같은데&quot;라며 effect를 또 돌려.
+          </p>
+          <div className='mt-3 space-y-1 text-xs'>
+            <div className='flex items-center gap-2'>
+              <span className='w-14 font-semibold text-red-600'>🔥 Chaos</span>
+              <span className='font-mono'>🔴 🔴 🔴 🔴 🔴</span>
+              <span className='text-gray-400'>매 렌더마다 effect 실행</span>
+            </div>
+            <div className='flex items-center gap-2'>
+              <span className='w-14 font-semibold text-emerald-600'>
+                ❄️ Calm
+              </span>
+              <span className='font-mono'>🔴 ⚪ ⚪ ⚪ ⚪</span>
+              <span className='text-gray-400'>진짜 바뀔 때만 실행</span>
+            </div>
+          </div>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 놀이기구 B에서 직접 눌러보며 effect 카운터로 확인
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/usememo/ObjectReferenceTrap.tsx
+++ b/src/components/playgrounds/usememo/ObjectReferenceTrap.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
 
 function TrapChild({ config }: { config: { limit: number } }) {
   const [runs, setRuns] = useState(0)
@@ -64,41 +65,98 @@ export default function ObjectReferenceTrap() {
         <TrapChild config={config} />
         <div className='rounded-lg bg-white p-4 text-sm ring-1 ring-gray-200'>
           <div className='text-xs font-semibold tracking-wider text-gray-500 uppercase'>
-            💡 무슨 일이 벌어지고 있는지
+            💡 지금 무슨 일이 벌어지는지
           </div>
           <p className='mt-2 text-gray-700'>
             {memoize ? (
               <>
-                <span className='text-emerald-600'>참조 안정</span>: 부모가 몇
-                번 리렌더되든 <code>config</code> 참조는 그대로. 자식의{' '}
-                <code>useEffect</code>는 <b>한 번만</b> 실행.
+                <span className='text-emerald-600'>같은 물건이야</span>: 부모가
+                몇 번 다시 그려지든 <code>config</code>는 똑같은 객체. 리액트가
+                &quot;어, 바뀐 거 없네&quot;하고 자식 <code>useEffect</code>를{' '}
+                <b>한 번만</b> 실행해.
               </>
             ) : (
               <>
-                <span className='text-red-600'>참조 새로 생성</span>: 리렌더마다{' '}
-                <code>{`{ limit: 10 }`}</code>이 새 객체. 자식의{' '}
-                <code>useEffect</code>가 <b>매 리렌더마다</b> 다시 돔.
+                <span className='text-red-600'>매번 다른 물건이야</span>:
+                리렌더마다 <code>{`{ limit: 10 }`}</code>을 새로 만드니까 내용은
+                같아도 <b>다른 객체</b>. 리액트가 &quot;달라졌네&quot; 하며 자식
+                <code>useEffect</code>를 <b>매번</b> 다시 돌려.
               </>
             )}
           </p>
         </div>
       </div>
 
-      <pre className='overflow-x-auto rounded-lg bg-gray-900 p-4 font-mono text-[12px] text-gray-100'>
-        {memoize
-          ? `// 부모
-const stable = useMemo(() => ({ limit: 10 }), [])
-<TrapChild config={stable} />
+      <div className='mb-4'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          ✍️ 코드로 비교하면
+        </div>
+        <BeforeAfter
+          before={{
+            label: 'ObjectRefTrap-before.tsx',
+            code: `function Parent() {
+  const [tick, setTick] = useState(0)
 
-// 자식
-useEffect(() => { ... }, [config])  // ✅ 마운트 1회만`
-          : `// 부모
-const fresh = { limit: 10 }  // ❌ 렌더마다 새 객체
-<TrapChild config={fresh} />
+  // 렌더될 때마다 새로 만들어지는 객체 리터럴
+  const fresh = { limit: 10 }
 
-// 자식
-useEffect(() => { ... }, [config])  // 🔁 매 리렌더마다 실행`}
-      </pre>
+  return <Child config={fresh} />
+}
+
+function Child({ config }: { config: { limit: number } }) {
+  useEffect(() => {
+    // 🔁 부모가 리렌더될 때마다 또 실행됨
+    console.log('effect run')
+  }, [config])
+  return null
+}`,
+            takeaway:
+              '내용이 같아도 매번 "다른 물건"이라 useEffect가 반복 실행 → 무한 네트워크 요청 같은 버그의 원인',
+          }}
+          after={{
+            label: 'ObjectRefTrap-after.tsx',
+            code: `function Parent() {
+  const [tick, setTick] = useState(0)
+
+  // 한 번 만들고 같은 물건을 계속 돌려줌
+  const stable = useMemo(() => ({ limit: 10 }), [])
+
+  return <Child config={stable} />
+}
+
+function Child({ config }: { config: { limit: number } }) {
+  useEffect(() => {
+    // ✅ 마운트 때 딱 1회만 실행
+    console.log('effect run')
+  }, [config])
+  return null
+}`,
+            takeaway:
+              'useMemo로 같은 참조를 유지하니 실제로 바뀔 때만 effect 실행 → 의도한 대로 동작',
+          }}
+        />
+      </div>
+
+      <div className='rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 왜 이걸 쓰는가 · 언제 쓰는가
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 <b>왜</b>: 자식의 <code>useEffect</code>·<code>React.memo</code>·
+            커스텀 훅이 <b>props를 참조로 비교</b>하기 때문. 같은 내용이어도
+            매번 새로 만들면 항상 &quot;달라졌다&quot;로 판단됨.
+          </li>
+          <li>
+            🕰️ <b>언제</b>: 객체·배열·함수를 <b>자식의 props</b>,{' '}
+            <b>다른 훅의 주시 목록</b>(deps), <b>context value</b>에 넘길 때.
+          </li>
+          <li>
+            ⚠️ <b>주의</b>: 렌더 안에서 쓰고 버릴 값이라면 memo가 없어도 됨.
+            &quot;참조 건너편에 누가 보고 있나&quot;가 판단 기준.
+          </li>
+        </ul>
+      </div>
     </div>
   )
 }

--- a/src/components/playgrounds/usememo/index.tsx
+++ b/src/components/playgrounds/usememo/index.tsx
@@ -1,10 +1,17 @@
 import ChaosCalm from './ChaosCalm'
+import GoalViz from './GoalViz'
 import ObjectReferenceTrap from './ObjectReferenceTrap'
 import PlaygroundSection from '@/components/stages/PlaygroundSection'
 
 export default function UseMemoPlayground() {
   return (
-    <div className='flex flex-col gap-10'>
+    <div className='flex flex-col gap-12'>
+      <PlayFirstBanner />
+      <Glossary />
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
       <PlaygroundSection
         index='A'
         emoji='🎢'
@@ -17,11 +24,73 @@ export default function UseMemoPlayground() {
       <PlaygroundSection
         index='B'
         emoji='🪤'
-        title='Object Reference Trap'
-        description='객체·배열·함수는 매 렌더마다 새 참조. 자식이 useEffect deps로 받으면 매번 다시 실행된다. useMemo로 참조를 얼려서 뭐가 달라지는지 직접 확인.'
+        title='Object Reference Trap (참조 함정)'
+        description='객체·배열·함수는 매번 새로 만들어진다. 자식이 useEffect 주시 목록으로 받으면 매번 새 물건이라 다시 실행된다. useMemo로 같은 물건을 유지해서 어떻게 달라지는지 직접 확인.'
       >
         <ObjectReferenceTrap />
       </PlaygroundSection>
+    </div>
+  )
+}
+
+function PlayFirstBanner() {
+  return (
+    <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+      <div className='flex items-start gap-3'>
+        <span className='text-3xl'>🎮</span>
+        <div>
+          <div className='font-extrabold'>일단 버튼부터 눌러봐</div>
+          <p className='mt-1 text-sm text-gray-700'>
+            이론을 다 읽고 시작하려 하지 마. 아래 <b>🎢 Chaos/Calm</b>과{' '}
+            <b>🪤 참조 함정</b>에서 버튼을 몇 번 눌러보고, &quot;어, 이게 왜
+            이러지?&quot; 싶을 때 설명을 읽으면 훨씬 빨리 감이 와.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Glossary() {
+  const terms: Array<{ term: string; simple: string; full?: string }> = [
+    {
+      term: '리렌더',
+      simple: '화면이 다시 그려지는 일',
+      full: '컴포넌트 함수가 처음부터 다시 실행되는 것',
+    },
+    {
+      term: '메모이제이션',
+      simple: '결과를 종이에 적어두고 재사용하기',
+      full: '이전에 계산한 결과를 저장해뒀다가, 같은 입력이면 다시 돌려쓰는 기법',
+    },
+    {
+      term: '참조 동일성',
+      simple: '진짜 같은 물건인지 확인',
+      full: '자바스크립트에서 ===로 객체·배열·함수를 비교할 때 "내용"이 아니라 "주소"를 비교한다는 규칙',
+    },
+    {
+      term: '주시 목록 (deps)',
+      simple: 'useEffect·useMemo가 지켜보는 값들의 배열',
+      full: '여기 있는 값이 바뀌면 effect/memo가 다시 실행됨',
+    },
+  ]
+  return (
+    <div>
+      <div className='mb-3 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+        📖 이 페이지에 나오는 용어
+      </div>
+      <div className='grid gap-2 rounded-2xl bg-white p-4 ring-1 ring-gray-100 sm:grid-cols-2'>
+        {terms.map((t) => (
+          <div key={t.term} className='text-[13px] leading-snug'>
+            <span className='font-bold'>{t.term}</span>{' '}
+            <span className='text-gray-500'>·</span>{' '}
+            <span className='text-gray-700'>{t.simple}</span>
+            {t.full && (
+              <div className='text-[11px] text-gray-400'>{t.full}</div>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/stages/BeforeAfter.tsx
+++ b/src/components/stages/BeforeAfter.tsx
@@ -1,0 +1,52 @@
+import CodeBlock from './CodeBlock'
+
+type Pair = {
+  label: string
+  code: string
+  takeaway: string
+}
+
+type Props = {
+  before: Pair
+  after: Pair
+}
+
+export default function BeforeAfter({ before, after }: Props) {
+  return (
+    <div className='grid gap-4 md:grid-cols-2'>
+      <Column label='🚫 이럴 때 문제' tone='red' pair={before} />
+      <Column label='✅ 이렇게 해결' tone='green' pair={after} />
+    </div>
+  )
+}
+
+function Column({
+  label,
+  tone,
+  pair,
+}: {
+  label: string
+  tone: 'red' | 'green'
+  pair: Pair
+}) {
+  const badgeClass =
+    tone === 'red' ? 'bg-red-50 text-red-700' : 'bg-emerald-50 text-emerald-700'
+  const takeawayClass =
+    tone === 'red' ? 'bg-red-50 text-red-800' : 'bg-emerald-50 text-emerald-800'
+
+  return (
+    <div>
+      <div
+        className={`mb-2 inline-block rounded-full px-3 py-1 text-xs font-bold ${badgeClass}`}
+      >
+        {label}
+      </div>
+      <CodeBlock filename={pair.label} code={pair.code} />
+      <p
+        className={`mt-2 rounded-lg p-2.5 text-xs font-medium ${takeawayClass}`}
+      >
+        {pair.takeaway}
+      </p>
+    </div>
+  )
+}

--- a/src/components/stages/CodeBlock.tsx
+++ b/src/components/stages/CodeBlock.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  code: string
+  filename?: string
+  lang?: string
+}
+
+export default function CodeBlock({ code, filename, lang = 'tsx' }: Props) {
+  return (
+    <div className='overflow-hidden rounded-xl bg-gray-900 shadow-sm ring-1 ring-gray-800'>
+      <div className='flex items-center justify-between border-b border-gray-800 px-4 py-2 text-xs text-gray-400'>
+        <span className='font-mono'>{filename ?? '예시 코드'}</span>
+        <span className='rounded bg-gray-800 px-2 py-0.5 text-[10px] font-bold tracking-wider uppercase'>
+          {lang}
+        </span>
+      </div>
+      <pre className='overflow-x-auto p-4 font-mono text-[12px] leading-relaxed text-gray-100'>
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}


### PR DESCRIPTION
closes #9

사용자 피드백 반영:
- **코드 예시** — 각 놀이기구에 Before/After 2단 비교 블록 추가 (실제 동작 코드 + takeaway 한 줄)
- **학습 목표 시각화** — 5종 GoalCard로 풀어쓰기 (동작 원리 비유, 결정 트리, 안티패턴, 참조 동일성 다이어그램, useEffect 관계 타임라인)
- **쉬운 설명** — 기술 용어 첫 등장 시 쉬운 한국어 + 괄호 병기 (리렌더, 메모이제이션, 참조 동일성, 주시 목록)
- **놀이 우선** — 상단 "🎮 일단 버튼부터 눌러봐" 배너 + 용어 사전 스트립

## 신규 컴포넌트
- `CodeBlock` — 파일명 태그 + 다크 코드 블록
- `BeforeAfter` — 🚫 문제 / ✅ 해결 2단 비교 + takeaway 카피
- `GoalViz` — useMemo 학습 목표 5개 시각화 카드

## 놀이기구 개선
- 각 놀이기구에 "💭 왜 · 언제 · 주의" 블록
- Chaos/Calm의 불필요한 `bump` prop 제거 (코드-해설 일치)
- Object Ref Trap의 인라인 `<pre>` 제거하고 BeforeAfter로 통합