### PR TITLE
✨ Feature: 정복 표시 MVP — 선언 버튼 + localStorage

### DIFF
--- a/src/components/quest/Dashboard.tsx
+++ b/src/components/quest/Dashboard.tsx
@@ -1,30 +1,31 @@
+'use client'
+
 import { totalExamples, totalStages } from '@/data/stages'
 import { achievements } from '@/data/achievements'
+import { completedCount, useProgress } from '@/lib/progress'
 
 type DashboardProps = {
-  stagesDone?: number
-  examplesDone?: number
   postsDone?: number
   postsTotal?: number
   badgesDone?: number
 }
 
 export default function Dashboard({
-  stagesDone = 0,
-  examplesDone = 0,
   postsDone = 0,
   postsTotal = 11,
   badgesDone = 0,
 }: DashboardProps) {
+  const progress = useProgress()
+  const stagesDone = completedCount(progress)
   const percent =
     totalStages === 0 ? 0 : Math.round((stagesDone / totalStages) * 100)
   const badgesTotal = achievements.length
 
   return (
-    <section className='mb-12 rounded-3xl bg-gradient-to-br from-[#ff5e48] to-[#ff8a65] p-8 text-white shadow-[0_20px_40px_-20px_rgba(255,94,72,0.4)]'>
+    <section className='mb-12 rounded-3xl bg-linear-to-br from-[#ff5e48] to-[#ff8a65] p-8 text-white shadow-[0_20px_40px_-20px_rgba(255,94,72,0.4)]'>
       <div className='mb-5 flex flex-wrap items-end justify-between gap-3'>
         <div>
-          <div className='text-xs font-semibold tracking-[0.1em] uppercase opacity-90'>
+          <div className='text-xs font-semibold tracking-widest uppercase opacity-90'>
             ⚔️ 전체 진도
           </div>
           <div className='mt-1 text-sm opacity-85'>
@@ -45,7 +46,7 @@ export default function Dashboard({
 
       <div className='grid grid-cols-2 gap-4 sm:grid-cols-4'>
         <Stat label='🎯 스테이지' value={`${stagesDone} / ${totalStages}`} />
-        <Stat label='🧪 예제' value={`${examplesDone} / ${totalExamples}`} />
+        <Stat label='🧪 예제' value={`— / ${totalExamples}`} />
         <Stat label='📝 블로그' value={`${postsDone} / ${postsTotal}`} />
         <Stat label='🏆 뱃지' value={`${badgesDone} / ${badgesTotal}`} />
       </div>

--- a/src/components/quest/QuestTabs.tsx
+++ b/src/components/quest/QuestTabs.tsx
@@ -8,6 +8,7 @@ import {
   type CategoryId,
   type Stage,
 } from '@/data/stages'
+import { completedInCategory, useProgress } from '@/lib/progress'
 import { cn } from '@/lib/cn'
 import StageCard from './StageCard'
 
@@ -18,6 +19,7 @@ type QuestTabsProps = {
 export default function QuestTabs({ initialTab }: QuestTabsProps) {
   const router = useRouter()
   const [tab, setTab] = useState<CategoryId>(initialTab)
+  const progress = useProgress()
 
   const activeMeta = categoryMeta.find((c) => c.id === tab) ?? categoryMeta[0]
   const visible = allStages.filter((s) => s.category === tab)
@@ -35,13 +37,19 @@ export default function QuestTabs({ initialTab }: QuestTabsProps) {
         className='-mx-2 mb-6 flex flex-wrap gap-2 overflow-x-auto px-2'
       >
         {categoryMeta.map((meta) => {
-          const count = allStages.filter((s) => s.category === meta.id).length
+          const inCategory = allStages.filter((s) => s.category === meta.id)
+          const total = inCategory.length
+          const done = completedInCategory(
+            progress,
+            inCategory.map((s) => s.id)
+          )
           const isActive = meta.id === tab
           return (
             <TabButton
               key={meta.id}
               meta={meta}
-              count={count}
+              done={done}
+              total={total}
               isActive={isActive}
               onSelect={handleSelect}
             />
@@ -66,15 +74,18 @@ export default function QuestTabs({ initialTab }: QuestTabsProps) {
 
 function TabButton({
   meta,
-  count,
+  done,
+  total,
   isActive,
   onSelect,
 }: {
   meta: (typeof categoryMeta)[number]
-  count: number
+  done: number
+  total: number
   isActive: boolean
   onSelect: (id: CategoryId) => void
 }) {
+  const cleared = total > 0 && done === total
   return (
     <button
       type='button'
@@ -84,12 +95,15 @@ function TabButton({
         'inline-flex shrink-0 items-center gap-2 rounded-full border-2 px-4 py-2 text-sm font-bold transition-all duration-200',
         isActive
           ? 'border-[#ff5e48] bg-[#ff5e48] text-white shadow-[0_4px_12px_-4px_rgba(255,94,72,0.5)]'
-          : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48] hover:text-[#ff5e48]'
+          : cleared
+            ? 'border-emerald-400 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
+            : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48] hover:text-[#ff5e48]'
       )}
     >
       <span>{meta.emoji}</span>
       <span>{meta.label}</span>
-      {meta.badge && (
+      {cleared && !isActive && <span className='text-xs'>👑</span>}
+      {meta.badge && !cleared && (
         <span
           className={cn('text-xs', isActive ? 'text-white' : 'text-[#ff5e48]')}
         >
@@ -99,10 +113,14 @@ function TabButton({
       <span
         className={cn(
           'rounded-full px-1.5 font-mono text-[11px]',
-          isActive ? 'bg-white/20 text-white' : 'bg-gray-100 text-gray-500'
+          isActive
+            ? 'bg-white/20 text-white'
+            : cleared
+              ? 'bg-emerald-200 text-emerald-900'
+              : 'bg-gray-100 text-gray-500'
         )}
       >
-        {count}
+        {done}/{total}
       </span>
     </button>
   )

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -1,6 +1,9 @@
+'use client'
+
 import Link from 'next/link'
 import type { Stage } from '@/data/stages'
 import { hasPlayground } from '@/data/playgrounds'
+import { isCompleted, useProgress } from '@/lib/progress'
 import { cn } from '@/lib/cn'
 import {
   difficultyBadge,
@@ -13,10 +16,13 @@ type StageCardProps = {
 }
 
 export default function StageCard({ stage }: StageCardProps) {
+  const progress = useProgress()
+  const done = isCompleted(stage.id, progress)
+  const effectiveStatus = done ? 'completed' : stage.status
   const statusIcon =
-    stage.status === 'completed'
+    effectiveStatus === 'completed'
       ? '✅'
-      : stage.status === 'active'
+      : effectiveStatus === 'active'
         ? '🔓'
         : '🔒'
   const playgroundReady = hasPlayground(stage.id)
@@ -26,13 +32,21 @@ export default function StageCard({ stage }: StageCardProps) {
       href={`/stages/${stage.id}`}
       aria-label={`${stage.title} 상세로 이동`}
       className={cn(
-        stageCardVariants({ status: stage.status, boss: stage.isBoss }),
+        stageCardVariants({ status: effectiveStatus, boss: stage.isBoss }),
         'block focus-visible:ring-2 focus-visible:ring-[#ff5e48] focus-visible:outline-none',
-        stage.status === 'locked' && 'hover:translate-y-0 hover:shadow-none'
+        effectiveStatus === 'locked' && 'hover:translate-y-0 hover:shadow-none'
       )}
     >
       {stage.isBoss && (
-        <div className='absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#8b5cf6] via-[#ec4899] to-[#f59e0b]' />
+        <div className='absolute inset-x-0 top-0 h-1 bg-linear-to-r from-[#8b5cf6] via-[#ec4899] to-[#f59e0b]' />
+      )}
+      {done && (
+        <div
+          aria-hidden
+          className='pointer-events-none absolute top-3 right-4 -rotate-12 rounded-md border-2 border-emerald-500 px-3 py-1 font-mono text-sm font-black tracking-wider text-emerald-500 opacity-90'
+        >
+          CLEAR!
+        </div>
       )}
 
       <header className='mb-4 flex items-start justify-between gap-3'>
@@ -49,7 +63,7 @@ export default function StageCard({ stage }: StageCardProps) {
               >
                 {difficultyLabel[stage.difficulty]}
               </span>
-              {stage.highlight && (
+              {stage.highlight && !done && (
                 <span className='text-xs font-bold text-[#ff5e48]'>
                   {stage.highlight}
                 </span>
@@ -71,7 +85,7 @@ export default function StageCard({ stage }: StageCardProps) {
         <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
       </div>
 
-      {stage.progress && (
+      {stage.progress && !done && (
         <footer className='mt-4 flex items-center justify-between border-t border-gray-100 pt-4 text-sm text-gray-500'>
           <span>{stage.progress.label}</span>
           <div className='flex items-center gap-2'>

--- a/src/components/stages/CompleteButton.tsx
+++ b/src/components/stages/CompleteButton.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import {
+  isCompleted,
+  markCompleted,
+  unmarkCompleted,
+  useProgress,
+} from '@/lib/progress'
+
+type Props = {
+  stageId: string
+}
+
+export default function CompleteButton({ stageId }: Props) {
+  const progress = useProgress()
+  const done = isCompleted(stageId, progress)
+  const completedAt = progress.completedAt[stageId]
+
+  if (done) {
+    return (
+      <div className='rounded-2xl border-2 border-emerald-400 bg-emerald-50 p-5 text-center'>
+        <div className='mb-1 text-2xl'>🏆</div>
+        <div className='font-extrabold text-emerald-800'>
+          이 스테이지를 정복했어요
+        </div>
+        <div className='mt-1 text-xs text-emerald-700'>
+          {completedAt
+            ? new Date(completedAt).toLocaleDateString('ko-KR', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })
+            : ''}
+        </div>
+        <button
+          type='button'
+          onClick={() => unmarkCompleted(stageId)}
+          className='mt-4 rounded-full border border-emerald-300 bg-white px-4 py-2 text-xs font-semibold text-emerald-700 hover:bg-emerald-100'
+        >
+          ↩️ 정복 취소하고 다시 연습
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-white p-5 text-center'>
+      <p className='mb-3 text-sm text-gray-600'>
+        놀이기구 전부 눌러봤고, 코드 비교도 이해했으면 아래 버튼으로 정복 인증!
+      </p>
+      <button
+        type='button'
+        onClick={() => markCompleted(stageId)}
+        className='inline-flex items-center gap-2 rounded-full bg-[#ff5e48] px-6 py-3 font-bold text-white shadow-sm transition hover:bg-[#ec4b36]'
+      >
+        ✅ 정복했어!
+      </button>
+    </div>
+  )
+}

--- a/src/components/stages/StageDetail.tsx
+++ b/src/components/stages/StageDetail.tsx
@@ -5,6 +5,7 @@ import {
   difficultyBadge,
   difficultyLabel,
 } from '@/components/quest/StageCard.variants'
+import CompleteButton from './CompleteButton'
 import PlaygroundPlaceholder from './PlaygroundPlaceholder'
 
 type Props = {
@@ -76,6 +77,10 @@ export default function StageDetail({ stage }: Props) {
         ) : (
           <PlaygroundPlaceholder stageTitle={stage.title} />
         )}
+      </section>
+
+      <section className='mt-10'>
+        <CompleteButton stageId={stage.id} />
       </section>
 
       <div className='mt-10 flex justify-center'>

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,0 +1,90 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+const STORAGE_KEY = 'quest-progress-v1'
+
+export type Progress = {
+  completedAt: Record<string, number>
+}
+
+const emptyProgress: Progress = { completedAt: {} }
+
+const listeners = new Set<() => void>()
+
+function readFromStorage(): Progress {
+  if (typeof window === 'undefined') return emptyProgress
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return emptyProgress
+    const parsed = JSON.parse(raw) as Progress
+    if (!parsed || typeof parsed !== 'object') return emptyProgress
+    return {
+      completedAt:
+        parsed.completedAt && typeof parsed.completedAt === 'object'
+          ? parsed.completedAt
+          : {},
+    }
+  } catch {
+    return emptyProgress
+  }
+}
+
+function writeToStorage(next: Progress): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  listeners.forEach((fn) => fn())
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn)
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) fn()
+  }
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', onStorage)
+  }
+  return () => {
+    listeners.delete(fn)
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('storage', onStorage)
+    }
+  }
+}
+
+export function useProgress(): Progress {
+  return useSyncExternalStore(subscribe, readFromStorage, () => emptyProgress)
+}
+
+export function markCompleted(stageId: string): void {
+  const current = readFromStorage()
+  writeToStorage({
+    ...current,
+    completedAt: {
+      ...current.completedAt,
+      [stageId]: Date.now(),
+    },
+  })
+}
+
+export function unmarkCompleted(stageId: string): void {
+  const current = readFromStorage()
+  const next = { ...current.completedAt }
+  delete next[stageId]
+  writeToStorage({ ...current, completedAt: next })
+}
+
+export function isCompleted(stageId: string, progress: Progress): boolean {
+  return progress.completedAt[stageId] != null
+}
+
+export function completedCount(progress: Progress): number {
+  return Object.keys(progress.completedAt).length
+}
+
+export function completedInCategory(
+  progress: Progress,
+  stageIds: string[]
+): number {
+  return stageIds.filter((id) => progress.completedAt[id] != null).length
+}


### PR DESCRIPTION
closes #11

셀프 선언 방식으로 스테이지 정복 여부를 저장·반영하는 MVP.

## 신규
- `src/lib/progress.ts` — localStorage 진도 저장소, `useSyncExternalStore`로 구독 동기화
- `CompleteButton` — 미완주/완주 모드 전환 (`✅ 정복했어!` / `↩️ 정복 취소`)

## 반영
- **StageCard**: 완주 시 비스듬한 `CLEAR!` 스탬프 + 초록 border/bg + `⭐ 지금 시작` 하이라이트·mini progress는 숨김
- **Dashboard**: 'use client'로 전환, stagesDone을 localStorage에서 자동 집계. 진도바 %가 실시간 반영
- **QuestTabs**: 탭 배지 `클리어/전체` 형식, 전부 클리어한 카테고리는 에메랄드 테두리 + 👑 아이콘

## 검증
- `npm run build` ✓ / `npm run lint` ✓
- 28개 스테이지 정적 생성 유지
- SSR 안전 (서버에서는 0으로 렌더 후 클라이언트에서 하이드레이트)

## 범위 외 (다음 PR 후보)
- 체크리스트 기반 부분 진도
- confetti / 뱃지 해금 토스트
- 탭 자체 잠금 해제