### PR TITLE
✨ Feature: 놀이기구 Batch 1 — 렌더링 · useState · Error Boundary

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,8 @@ import { jetbrainsMono } from './fonts'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: '🎮 React Quest',
-  description: '훅을 눌러보고, 망가뜨리고, 체화하는 놀이터',
+  title: '🎮 React Playground',
+  description: '개념을 눌러보고, 망가뜨리고, 체화하는 놀이터',
 }
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default async function Home({ searchParams }: HomeProps) {
       <section className='mb-14 text-center'>
         <div className='animate-quest-bounce mb-4 text-7xl'>🎮</div>
         <h1 className='mb-3 text-5xl font-black tracking-[-0.02em] sm:text-[56px]'>
-          React <span className='text-[#ff5e48]'>Quest</span>
+          React <span className='text-[#ff5e48]'>Playground</span>
         </h1>
         <p className='text-lg text-gray-500'>
           훅을 눌러보고, 망가뜨리고, 체화하는 놀이터

--- a/src/components/playgrounds/error-boundary/Explosion.tsx
+++ b/src/components/playgrounds/error-boundary/Explosion.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { Component, ReactNode, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type BoundaryState = { error: Error | null }
+
+class MiniErrorBoundary extends Component<
+  {
+    children: ReactNode
+    fallback: (reset: () => void, err: Error) => ReactNode
+    resetKey: number
+  },
+  BoundaryState
+> {
+  state: BoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { error }
+  }
+
+  componentDidUpdate(prev: { resetKey: number }): void {
+    if (prev.resetKey !== this.props.resetKey && this.state.error) {
+      this.setState({ error: null })
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return this.props.fallback(
+        () => this.setState({ error: null }),
+        this.state.error
+      )
+    }
+    return this.props.children
+  }
+}
+
+function DangerousChild({ shouldExplode }: { shouldExplode: boolean }) {
+  if (shouldExplode) {
+    throw new Error('💥 자식 컴포넌트가 터졌어요')
+  }
+  return (
+    <div className='rounded-xl bg-emerald-50 p-6 text-center ring-1 ring-emerald-200'>
+      <div className='mb-1 text-3xl'>😌</div>
+      <div className='font-bold text-emerald-800'>
+        자식은 평화롭게 렌더되는 중
+      </div>
+      <div className='mt-1 text-xs text-emerald-700'>
+        오른쪽 &quot;💥 터뜨리기&quot; 버튼을 눌러 에러를 던져보세요
+      </div>
+    </div>
+  )
+}
+
+export default function Explosion() {
+  const [useBoundary, setUseBoundary] = useState(true)
+  const [shouldExplode, setShouldExplode] = useState(false)
+  const [resetKey, setResetKey] = useState(0)
+
+  const handleExplode = () => setShouldExplode(true)
+  const handleReset = () => {
+    setShouldExplode(false)
+    setResetKey((k) => k + 1)
+  }
+
+  const child = <DangerousChild shouldExplode={shouldExplode} />
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setUseBoundary((v) => !v)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            useBoundary
+              ? 'bg-emerald-500 text-white'
+              : 'border border-red-300 bg-white text-red-600'
+          )}
+        >
+          {useBoundary ? '🛡️ Error Boundary 씌워짐' : '🧨 Error Boundary 없음'}
+        </button>
+        <button
+          type='button'
+          onClick={handleExplode}
+          disabled={shouldExplode}
+          className='rounded-full bg-red-500 px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-red-600 disabled:opacity-50'
+        >
+          💥 자식 터뜨리기
+        </button>
+        <button
+          type='button'
+          onClick={handleReset}
+          className='rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-600 hover:border-gray-300'
+        >
+          ↺ 다시 시도
+        </button>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm ring-1 ring-gray-100'>
+        <p className='text-gray-700'>
+          🎯 <b>관찰 포인트</b>:
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            🛡️ Error Boundary <b>있을 때</b> 터뜨리면 → 폴백 UI로 대체되고 앱은
+            살아있음. &quot;다시 시도&quot;로 복구 가능.
+          </li>
+          <li>
+            🧨 Error Boundary <b>없을 때</b> 터뜨리면 → 아래 UI가 통째로
+            사라지고 상위 트리까지 영향. (실제 프로덕션에선 전체 앱 하얗게 됨)
+          </li>
+        </ul>
+      </div>
+
+      <div className='mb-4 rounded-2xl bg-white p-4 ring-1 ring-gray-100'>
+        {useBoundary ? (
+          <MiniErrorBoundary
+            resetKey={resetKey}
+            fallback={(reset, err) => (
+              <div className='rounded-xl bg-red-50 p-6 text-center ring-1 ring-red-200'>
+                <div className='mb-1 text-3xl'>🧯</div>
+                <div className='font-bold text-red-800'>폴백 UI가 떴어요</div>
+                <div className='mt-1 font-mono text-xs text-red-700'>
+                  {err.message}
+                </div>
+                <button
+                  type='button'
+                  onClick={() => {
+                    setShouldExplode(false)
+                    reset()
+                  }}
+                  className='mt-3 rounded-full bg-red-500 px-4 py-1.5 text-xs font-bold text-white hover:bg-red-600'
+                >
+                  🔁 다시 시도
+                </button>
+              </div>
+            )}
+          >
+            {child}
+          </MiniErrorBoundary>
+        ) : shouldExplode ? (
+          <div className='rounded-xl bg-gray-900 p-6 text-center text-gray-100'>
+            <div className='mb-1 text-3xl'>💀</div>
+            <div className='font-bold'>앱이 하얗게 됐어요</div>
+            <div className='mt-1 text-xs opacity-80'>
+              (시뮬레이션: 실제로는 전체 트리가 언마운트됨)
+            </div>
+            <button
+              type='button'
+              onClick={handleReset}
+              className='mt-3 rounded-full bg-gray-200 px-4 py-1.5 text-xs font-bold text-gray-900 hover:bg-white'
+            >
+              🔄 새로고침 느낌으로 다시
+            </button>
+          </div>
+        ) : (
+          child
+        )}
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ Error Boundary 없이',
+          code: `function App() {
+  return (
+    <div>
+      <Header />
+      <Dangerous /> {/* 여기서 throw 되면 */}
+      <Footer />    {/* Header·Footer까지 함께 언마운트 */}
+    </div>
+  )
+}`,
+          takeaway:
+            '자식 하나의 오류가 상위로 번져서 화면 전체가 사라짐 — 사용자는 그냥 흰 화면만 봄',
+        }}
+        after={{
+          label: '✅ Error Boundary 로 격리',
+          code: `function App() {
+  return (
+    <div>
+      <Header />
+      <ErrorBoundary fallback={<ErrorFallback />}>
+        <Dangerous />
+      </ErrorBoundary>
+      <Footer />
+    </div>
+  )
+}`,
+          takeaway:
+            '오류를 특정 구역에만 가두고 나머지 UI는 살려둠 + 복구 버튼 제공 가능',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 꼭 기억할 것
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            ✅ <b>잡는 것</b>: 렌더 중에 throw된 에러, 라이프사이클 오류, 자식
+            컴포넌트 오류
+          </li>
+          <li>
+            ❌ <b>못 잡는 것</b>: 이벤트 핸들러(버튼 onClick) 오류, 비동기{' '}
+            <code>setTimeout</code>/fetch 오류, Error Boundary 자신이 낸 오류,
+            SSR 오류
+          </li>
+          <li>
+            🎯 실전에선{' '}
+            <code className='bg-gray-100 px-1'>react-error-boundary</code>{' '}
+            패키지를 쓰면 훅·hookless 둘 다 깔끔하게 지원
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/error-boundary/GoalViz.tsx
+++ b/src/components/playgrounds/error-boundary/GoalViz.tsx
@@ -1,0 +1,150 @@
+import { ReactNode } from 'react'
+
+export default function ErrorBoundaryGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          에러는 피할 수 없어. &quot;어떻게 격리하고 되살릴지&quot; 가 포인트.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🧯'
+          title='잡는 것 / 못 잡는 것'
+          hook='모든 에러를 잡는 마법이 아니다'
+        >
+          <p>
+            Error Boundary가 <b>잡아주는</b> 영역:
+          </p>
+          <ul className='mt-1 space-y-0.5 text-[13px]'>
+            <li>✅ 하위 트리의 렌더 중 throw</li>
+            <li>✅ 라이프사이클 메서드 오류</li>
+            <li>✅ 생성자 오류</li>
+          </ul>
+          <p className='mt-2'>
+            반대로 <b>못 잡는</b> 영역:
+          </p>
+          <ul className='mt-1 space-y-0.5 text-[13px]'>
+            <li>❌ 이벤트 핸들러 (onClick 등)</li>
+            <li>❌ setTimeout / Promise / fetch 비동기</li>
+            <li>❌ SSR 중에 발생한 오류</li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 비동기는 try/catch + toast, 이벤트 핸들러는 try/catch로 따로
+            처리.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='📦'
+          title='react-error-boundary 패키지'
+          hook='클래스 컴포넌트 안 쓰고 훅으로 쓰는 표준'
+        >
+          <p>
+            리액트 자체는 아직 Error Boundary를 <b>클래스 컴포넌트</b>로만
+            제공해. 프로덕션에선{' '}
+            <code className='bg-gray-100 px-1'>react-error-boundary</code>{' '}
+            패키지가 사실상 표준.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`import { ErrorBoundary } from 'react-error-boundary'
+
+<ErrorBoundary
+  FallbackComponent={ErrorFallback}
+  onReset={() => resetApp()}
+>
+  <Dangerous />
+</ErrorBoundary>`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            <code>useErrorBoundary()</code> 훅으로 수동 throw도 가능.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🎭'
+          title='Suspense + Error Boundary 조합'
+          hook='로딩은 Suspense, 실패는 Error Boundary'
+        >
+          <p>
+            데이터 페칭에서는 둘을 함께 써. 순서는 <b>ErrorBoundary가 바깥</b>,
+            Suspense가 안쪽.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`<ErrorBoundary fallback={<Err />}>
+  <Suspense fallback={<Loading />}>
+    <Posts />
+  </Suspense>
+</ErrorBoundary>`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            로딩 중엔 Loading, 실패하면 Err, 성공하면 Posts.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🔁'
+          title='복구 가능한 폴백 UI'
+          hook='에러 = 끝 아님. 다시 시도할 여지'
+        >
+          <p>좋은 폴백 UI는 세 가지를 갖춰야 해:</p>
+          <ol className='mt-2 list-decimal space-y-1 pl-5 text-[13px]'>
+            <li>
+              <b>무엇이 잘못됐는지</b> 사용자 언어로 (&quot;서버와 연결이
+              끊겼어요&quot;)
+            </li>
+            <li>
+              <b>다시 시도 버튼</b> — 상태 리셋
+            </li>
+            <li>
+              <b>피해 범위 격리</b> — 주변 UI는 유지
+            </li>
+          </ol>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            놀이기구에서 &quot;🔁 다시 시도&quot; 버튼으로 state를 리셋해
+            복구되는 흐름을 체험.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/error-boundary/index.tsx
+++ b/src/components/playgrounds/error-boundary/index.tsx
@@ -1,0 +1,36 @@
+import Explosion from './Explosion'
+import GoalViz from './GoalViz'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function ErrorBoundaryPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>자식을 진짜로 터뜨려보자</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              💥 버튼으로 자식에 에러를 던지고, Error Boundary 토글을 껐다 켰다
+              해보자. &quot;있을 때&quot;와 &quot;없을 때&quot; 의 차이를 직접
+              느낄 수 있어.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🧯'
+        title='자식 폭파 + 폴백 UI + 다시 시도'
+        description='Error Boundary 유무 토글 + 자식 throw + 폴백 UI 렌더 + 복구 버튼. 실제 서비스에서 쓸 패턴 그대로.'
+      >
+        <Explosion />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/rendering/GoalViz.tsx
+++ b/src/components/playgrounds/rendering/GoalViz.tsx
@@ -1,0 +1,141 @@
+import { ReactNode } from 'react'
+
+export default function RenderingGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          &quot;리렌더&quot; 이 한 단어부터 확실히 잡자.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='⏯️'
+          title='언제 다시 그려질까?'
+          hook='state 또는 props가 바뀌면 그 컴포넌트와 자식들이 리렌더'
+        >
+          <p>리액트가 컴포넌트를 다시 그리는 순간은 크게 세 가지야.</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🟢 <b>state가 바뀔 때</b> (<code>setState</code> 호출)
+            </li>
+            <li>
+              🟢 <b>props가 바뀔 때</b> (부모가 새 값을 넘길 때)
+            </li>
+            <li>
+              🟢 <b>부모가 리렌더될 때</b> (자식도 따라서 — 기본 동작)
+            </li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 놀이기구에서 부모 버튼 한 번 누를 때마다 자식 숫자가 올라가는 걸
+            확인해봐.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🎬'
+          title='Render → Commit 2단계'
+          hook='머릿속 설계(Render) → 화면 실제 적용(Commit)'
+        >
+          <p>리렌더는 실제로 2단계야.</p>
+          <ol className='mt-2 list-decimal space-y-1.5 pl-5 text-[13px]'>
+            <li>
+              <b>Render 단계</b>: 컴포넌트 함수 실행 → 새 가상 DOM 트리 계산. 이
+              단계는 아직 화면에 아무 영향 없음.
+            </li>
+            <li>
+              <b>Commit 단계</b>: 바뀐 부분만 실제 DOM에 반영 + useEffect 실행.
+              여기서 화면이 진짜 바뀜.
+            </li>
+          </ol>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            그래서 리렌더가 많아도 DOM이 안 바뀌면 사용자는 못 느껴. 하지만
+            Render 단계 자체도 CPU를 쓰기 때문에 줄이는 게 좋아.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='📉'
+          title='메모이제이션이 왜 필요한지'
+          hook='불필요한 리렌더를 건너뛰기 위한 장치'
+        >
+          <p>
+            자식이 많거나 계산이 무거운 컴포넌트가 있을 때, 부모의 사소한
+            변경으로 전체가 리렌더되면 브라우저가 바빠져.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🧙‍♂️ <code>useMemo</code>: 무거운 계산 결과 캐싱
+            </li>
+            <li>
+              🎯 <code>useCallback</code>: 함수 참조 고정
+            </li>
+            <li>
+              🛡️ <code>React.memo</code>: 자식 컴포넌트의 리렌더 스킵
+            </li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            이 세 가지는 세트로 움직임. 다음 스테이지들에서 하나씩 깊게 다룸.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🧪'
+          title='React.StrictMode의 역할'
+          hook='개발 중 함수를 두 번 실행해 부작용을 드러냄'
+        >
+          <p>
+            <code>&lt;StrictMode&gt;</code>로 감싼 트리는 <b>개발 모드에서만</b>{' '}
+            컴포넌트 함수와 effect를 2번 실행해.
+          </p>
+          <p className='mt-2'>
+            이건 버그가 아니라 기능. &quot;내 컴포넌트가 두 번 실행돼도
+            안전한가?&quot;를 확인시켜 줘. side effect가 순수하지 않으면 여기서
+            티 나.
+          </p>
+          <p className='mt-3 rounded-lg bg-amber-50 p-2 text-[12px] text-amber-900'>
+            ⚠️ 프로덕션 빌드에선 한 번만 실행되니까 걱정 X
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/rendering/RenderFlow.tsx
+++ b/src/components/playgrounds/rendering/RenderFlow.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { memo, useRef, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type ChildProps = {
+  id: string
+  bg: string
+}
+
+function ChildInner({ id, bg }: ChildProps) {
+  const renders = useRef(0)
+  // 교육용 렌더 카운터 — 의도된 렌더 중 ref 조작
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center gap-1 rounded-xl p-4 text-center',
+        bg
+      )}
+    >
+      <span className='text-2xl'>{id}</span>
+      <span className='font-mono text-xs text-gray-600'>내가 그려진 횟수</span>
+      {/* eslint-disable-next-line react-hooks/refs */}
+      <span className='font-mono text-2xl font-bold'>{renders.current}</span>
+    </div>
+  )
+}
+
+const ChildMemo = memo(ChildInner)
+
+export default function RenderFlow() {
+  const [parentRenders, setParentRenders] = useState(0)
+  const [isMemoOn, setIsMemoOn] = useState(false)
+
+  const Child = isMemoOn ? ChildMemo : ChildInner
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setParentRenders((r) => r + 1)}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-[#ec4b36]'
+        >
+          🎲 부모 리렌더 {parentRenders}
+        </button>
+        <button
+          type='button'
+          onClick={() => setIsMemoOn((v) => !v)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            isMemoOn
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          {isMemoOn ? '✅ React.memo 켜짐' : '⬜️ React.memo 꺼짐'}
+        </button>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 ring-1 ring-gray-100'>
+        <p className='text-sm text-gray-700'>
+          {isMemoOn ? (
+            <>
+              🛡️ <b>React.memo</b>로 자식을 감쌌어. 부모만 리렌더되고 자식
+              props가 그대로면, 리액트는 자식 리렌더를 <b>건너뛰어</b>. 카운터
+              숫자가 그대로인지 봐봐.
+            </>
+          ) : (
+            <>
+              🎡 부모 버튼을 누르면 부모가 리렌더돼. 기본 동작은{' '}
+              <b>자식들도 전부 함께 리렌더</b>되는 거야. 자식 카드 안의 숫자가
+              계속 올라가는 걸 보고 느껴봐.
+            </>
+          )}
+        </p>
+      </div>
+
+      <div className='mb-4 grid grid-cols-3 gap-3 rounded-xl bg-linear-to-br from-indigo-50 to-violet-50 p-4'>
+        <Child id='🟢' bg='bg-white' />
+        <Child id='🔵' bg='bg-white' />
+        <Child id='🟠' bg='bg-white' />
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: 'React.memo 없이',
+          code: `function Child({ label }: { label: string }) {
+  return <div>{label}</div>
+}
+
+// 부모가 리렌더될 때마다 자식도 함께 리렌더됨`,
+          takeaway:
+            '부모가 state를 바꾸면 자식도 전부 다시 그려짐. 자식이 무거우면 부하 ↑',
+        }}
+        after={{
+          label: 'React.memo로 감싸면',
+          code: `const Child = memo(function Child({ label }: { label: string }) {
+  return <div>{label}</div>
+})
+
+// props 참조가 같으면 React가 리렌더를 스킵함`,
+          takeaway:
+            'props가 그대로면 리액트가 "어차피 같다"고 판단해 자식 리렌더 스킵',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 왜 이게 중요한가
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 기본 규칙: <b>부모가 다시 그려지면 자식도 다시 그려진다</b>.
+            리렌더는 전염돼.
+          </li>
+          <li>
+            🕰️ 대부분의 경우 이 전염은 빨라서 문제 없음. 근데 리스트가 크거나
+            계산이 무거운 자식이 있으면 체감이 시작돼.
+          </li>
+          <li>
+            🛡️ <b>React.memo</b>는 &quot;props가 같으면 나는 안 그려도 돼&quot;
+            라고 약속하는 껍데기. useMemo/useCallback으로 props 참조를 같이
+            지켜줘야 진짜 효과.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/rendering/index.tsx
+++ b/src/components/playgrounds/rendering/index.tsx
@@ -1,0 +1,36 @@
+import GoalViz from './GoalViz'
+import RenderFlow from './RenderFlow'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function RenderingPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>일단 부모 버튼부터 눌러봐</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              아래 놀이기구에서 부모 리렌더 버튼을 연타한 뒤, React.memo 토글을
+              켰다 껐다 해봐. 자식 카드의 숫자가 어떻게 바뀌는지가 오늘의 관찰
+              포인트야.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🎢'
+        title='리렌더 전파 시각화'
+        description='부모 리렌더가 자식에게 어떻게 번지는지 자식 카드의 "내가 그려진 횟수"로 확인. React.memo를 켜면 전염이 끊긴다.'
+      >
+        <RenderFlow />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usestate/BatchUpdate.tsx
+++ b/src/components/playgrounds/usestate/BatchUpdate.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+export default function BatchUpdate() {
+  const [count, setCount] = useState(0)
+  const renders = useRef(0)
+  // 교육용 렌더 카운터 — 의도된 렌더 중 ref 조작
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+
+  const handleBatchedClick = () => {
+    setCount((c) => c + 1)
+    setCount((c) => c + 1)
+    setCount((c) => c + 1)
+  }
+
+  const handleNaiveClick = () => {
+    // 함수형이 아닌 값 기반. 같은 count(0)에 1씩 더해서 3번 호출해봐야 최종 1.
+    setCount(count + 1)
+    setCount(count + 1)
+    setCount(count + 1)
+  }
+
+  const handleReset = () => {
+    setCount(0)
+    renders.current = 0
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 grid grid-cols-2 gap-3 rounded-xl bg-white p-4 shadow-sm sm:grid-cols-3'>
+        <Stat label='📦 count' value={count} />
+        {/* eslint-disable-next-line react-hooks/refs */}
+        <Stat label='🔁 렌더 횟수' value={renders.current} />
+        <Stat label='기대값' value='+3씩 올라야 함' raw />
+      </div>
+
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={handleBatchedClick}
+          className='rounded-full bg-emerald-500 px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-emerald-600'
+        >
+          ✅ 함수형으로 +3 (c =&gt; c + 1)
+        </button>
+        <button
+          type='button'
+          onClick={handleNaiveClick}
+          className='rounded-full bg-red-500 px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-red-600'
+        >
+          ❌ 값으로 +3 (count + 1)
+        </button>
+        <button
+          type='button'
+          onClick={handleReset}
+          className={cn(
+            'rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-600 hover:border-gray-300'
+          )}
+        >
+          ↺ 리셋
+        </button>
+      </div>
+
+      <div className='mb-4 rounded-lg bg-white p-4 text-sm ring-1 ring-gray-100'>
+        <p className='text-gray-700'>
+          🎯 <b>관찰 포인트</b>: 두 버튼을 번갈아 눌러봐.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            ✅ <b>함수형</b>은 <code>setCount(c =&gt; c + 1)</code> 3번 →
+            count가 +3. 리액트가 3번을 한 렌더로 batch하고, 함수형이라 직전 상태
+            위에 누적됨.
+          </li>
+          <li>
+            ❌ <b>값 기반</b>은 <code>setCount(count + 1)</code> 3번 → 세 번 다
+            같은 값(count=0이면 전부 1)을 넣어서 결국 +1. 클로저에 갇힌 값 문제.
+          </li>
+        </ul>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ 값 기반 업데이트',
+          code: `const [count, setCount] = useState(0)
+
+function addThree() {
+  setCount(count + 1) // count === 0 → 1 넣음
+  setCount(count + 1) // count 여전히 0 → 1 넣음
+  setCount(count + 1) // count 여전히 0 → 1 넣음
+}
+// 결과: count === 1`,
+          takeaway:
+            '클로저 안 count는 렌더 당시 값으로 고정. 세 번 다 같은 계산 → 마지막만 반영',
+        }}
+        after={{
+          label: '✅ 함수형 업데이트',
+          code: `const [count, setCount] = useState(0)
+
+function addThree() {
+  setCount(c => c + 1) // 큐에 "직전+1" 등록
+  setCount(c => c + 1)
+  setCount(c => c + 1)
+}
+// 결과: count === 3`,
+          takeaway:
+            '함수형은 "직전 값에 +1" 로직을 큐에 쌓음. React가 순서대로 적용해서 누적됨',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 왜 · 언제
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 <b>왜</b>: React는 한 이벤트 핸들러 안의 여러{' '}
+            <code>setState</code>를 <b>batch</b>해서 한 번만 렌더해. 이때
+            &quot;직전 값&quot;을 알려면 함수형이 필요해.
+          </li>
+          <li>
+            🕰️ <b>언제</b>: 같은 state를 연속해서 업데이트하거나,{' '}
+            <code>setTimeout</code>·이벤트 핸들러 안에서 값을 증분할 때.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  raw,
+}: {
+  label: string
+  value: string | number
+  raw?: boolean
+}) {
+  return (
+    <div>
+      <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        {label}
+      </div>
+      <div
+        className={cn(
+          'mt-0.5 font-mono font-bold',
+          raw ? 'text-xs text-gray-500' : 'text-2xl'
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usestate/GoalViz.tsx
+++ b/src/components/playgrounds/usestate/GoalViz.tsx
@@ -1,0 +1,129 @@
+import { ReactNode } from 'react'
+
+export default function UseStateGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          단순해 보여도 의외로 함정이 많은 훅.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='📦'
+          title='배치 업데이트 (batching)'
+          hook='여러 setState를 묶어 한 번만 렌더'
+        >
+          <p>
+            한 이벤트 핸들러 안에서 <code>setState</code>를 여러 번 호출해도
+            리액트는 <b>한 번만 렌더</b>해. 그게 성능 최적화의 기본.
+          </p>
+          <p className='mt-2'>
+            React 18부터는 <code>setTimeout</code>·<code>await</code>·Promise
+            안에서도 batch가 작동해 (Automatic Batching).
+          </p>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 놀이기구 A에서 &quot;함수형 +3&quot; 눌러보고 렌더 횟수가 1만
+            오르는지 확인.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🐌'
+          title='게으른 초기화 (Lazy Init)'
+          hook='초기값 계산이 무거우면 함수로 넘겨라'
+        >
+          <p>
+            <code>useState(heavy())</code>는 <b>매 렌더마다</b> heavy()를 호출해
+            (결과는 무시돼도). 반면 <code>useState(() =&gt; heavy())</code>는{' '}
+            <b>처음 한 번만</b> 호출.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// ❌ 매 렌더마다 heavy() 실행
+useState(heavy())
+
+// ✅ 마운트 때 한 번만
+useState(() => heavy())`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🔄'
+          title='함수형 vs 값 업데이트'
+          hook='직전 state에 의존할 땐 함수형'
+        >
+          <p>
+            <code>setCount(count + 1)</code>은 렌더 당시의 count에 의존. 여러 번
+            쌓이거나 <code>setTimeout</code>에 들어가면 &quot;옛날 값&quot;으로
+            계산돼.
+          </p>
+          <p>
+            <code>setCount(c =&gt; c + 1)</code>은 &quot;지금 이 순간의 최신값에
+            +1&quot;이란 약속이라 언제 실행돼도 안전.
+          </p>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 놀이기구 B가 이 차이를 극적으로 보여줌.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='⏱️'
+          title='setState의 비동기 동작'
+          hook='setState는 즉시 반영되지 않는다'
+        >
+          <p>
+            <code>setCount(5)</code> 바로 뒤에 <code>console.log(count)</code>{' '}
+            찍으면? 여전히 예전 값이야. count는 &quot;다음 렌더에&quot;
+            업데이트돼.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`setCount(5)
+console.log(count) // ❌ 아직 옛날 값`}
+          </pre>
+          <p className='mt-2'>
+            업데이트 후의 값이 필요하면 <code>useEffect([count], ...)</code>{' '}
+            에서 반응하거나, 함수형 업데이트 안에서 접근해.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/usestate/StaleClosure.tsx
+++ b/src/components/playgrounds/usestate/StaleClosure.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+export default function StaleClosure() {
+  const [count, setCount] = useState(0)
+  const [lastAlert, setLastAlert] = useState<string | null>(null)
+
+  const handleValueBased = () => {
+    setLastAlert(null)
+    setTimeout(() => {
+      // 이 안의 count는 버튼 누른 순간의 스냅샷에 갇혀있음
+      setLastAlert(`❌ 값 기반: 5초 전 count는 ${count}이었어`)
+    }, 3000)
+  }
+
+  const handleFunctional = () => {
+    setLastAlert(null)
+    setTimeout(() => {
+      setCount((c) => {
+        setLastAlert(`✅ 함수형: 지금 이 순간 count는 ${c}야 (변경 없이 확인)`)
+        return c // 실제로 바꾸지 않음
+      })
+    }, 3000)
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 grid grid-cols-2 gap-3 rounded-xl bg-white p-4 shadow-sm'>
+        <div>
+          <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+            📦 현재 count
+          </div>
+          <div className='mt-0.5 font-mono text-3xl font-bold'>{count}</div>
+        </div>
+        <div className='flex flex-col gap-1'>
+          <button
+            type='button'
+            onClick={() => setCount((c) => c + 1)}
+            className='rounded-full bg-gray-900 px-3 py-1 text-xs font-bold text-white hover:bg-gray-700'
+          >
+            ➕ count +1
+          </button>
+          <button
+            type='button'
+            onClick={() => setCount(0)}
+            className='rounded-full border border-gray-200 px-3 py-1 text-xs font-semibold text-gray-600 hover:border-gray-300'
+          >
+            ↺ 리셋
+          </button>
+        </div>
+      </div>
+
+      <div className='mb-4 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p className='mb-2'>
+          🎯 <b>실험</b>: 버튼 누른 뒤 <b>3초 안에</b> 위의 &quot;count
+          +1&quot;을 여러 번 눌러 count를 올려봐. 3초 뒤에 튀어나오는 메시지가
+          어느 시점의 값을 보여주는지 비교.
+        </p>
+      </div>
+
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={handleValueBased}
+          className='rounded-full bg-red-500 px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-red-600'
+        >
+          ❌ 값 기반 setTimeout (3초 후)
+        </button>
+        <button
+          type='button'
+          onClick={handleFunctional}
+          className='rounded-full bg-emerald-500 px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-emerald-600'
+        >
+          ✅ 함수형으로 현재값 확인 (3초 후)
+        </button>
+      </div>
+
+      {lastAlert && (
+        <div className='mb-4 rounded-lg border border-gray-200 bg-white p-4 font-mono text-sm'>
+          {lastAlert}
+        </div>
+      )}
+
+      <BeforeAfter
+        before={{
+          label: '❌ Stale Closure 트랩',
+          code: `function Component() {
+  const [count, setCount] = useState(0)
+
+  const showLater = () => {
+    setTimeout(() => {
+      console.log(count) // 버튼 누른 순간의 count에 갇힘
+    }, 3000)
+  }
+
+  return <button onClick={showLater}>보기</button>
+}`,
+          takeaway:
+            'setTimeout 안 count는 콜백이 만들어진 시점의 값으로 얼어있음. 최신 값이 아님',
+        }}
+        after={{
+          label: '✅ 함수형 업데이트로 최신값',
+          code: `function Component() {
+  const [count, setCount] = useState(0)
+
+  const showLater = () => {
+    setTimeout(() => {
+      setCount(latest => {
+        console.log(latest) // 지금 이 순간의 최신 count
+        return latest // 값은 그대로
+      })
+    }, 3000)
+  }
+
+  return <button onClick={showLater}>보기</button>
+}`,
+          takeaway:
+            '함수형 콜백은 React가 호출하는 시점에 "가장 최신" state를 주입해줌',
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/playgrounds/usestate/index.tsx
+++ b/src/components/playgrounds/usestate/index.tsx
@@ -1,0 +1,47 @@
+import BatchUpdate from './BatchUpdate'
+import GoalViz from './GoalViz'
+import StaleClosure from './StaleClosure'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseStatePlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              값 기반 vs 함수형 업데이트, 직접 실수해보자
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              두 놀이기구 다 &quot;왜 내 count가 이상하지?&quot; 를 재현하는
+              실험이야. 빨간 버튼부터 먼저 눌러서 망가뜨려봐.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='📦'
+        title='Batch 업데이트 실험'
+        description='같은 이벤트 안에서 setState를 3번 연속 호출. 값 기반이면 +1만, 함수형이면 +3. React의 batching을 눈으로 확인.'
+      >
+        <BatchUpdate />
+      </PlaygroundSection>
+
+      <PlaygroundSection
+        index='B'
+        emoji='⏳'
+        title='Stale Closure 트랩'
+        description='setTimeout 안의 state는 버튼 누른 순간에 얼어붙는다. 3초 기다리는 동안 count를 바꿔보고, 결과가 어느 시점 값인지 비교.'
+      >
+        <StaleClosure />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/data/playgrounds.ts
+++ b/src/data/playgrounds.ts
@@ -1,8 +1,14 @@
 import type { ComponentType } from 'react'
 import UseMemoPlayground from '@/components/playgrounds/usememo'
+import RenderingPlayground from '@/components/playgrounds/rendering'
+import UseStatePlayground from '@/components/playgrounds/usestate'
+import ErrorBoundaryPlayground from '@/components/playgrounds/error-boundary'
 
 export const playgrounds: Record<string, ComponentType> = {
+  'stage-1-rendering': RenderingPlayground,
   'stage-2-usememo': UseMemoPlayground,
+  'stage-5-usestate': UseStatePlayground,
+  'stage-error-boundary': ErrorBoundaryPlayground,
 }
 
 export const hasPlayground = (stageId: string): boolean =>


### PR DESCRIPTION
closes #15

🎣 훅 탭 학습 초반 3스테이지를 useMemo 품질로 구현. 각 스테이지에 "일단 해봐" 배너 → GoalViz 카드 4개 → 놀이기구 → Before/After → 왜·언제 블록 순서 적용.

## 스테이지별

**렌더링 기초** (`/stages/stage-1-rendering`)
- RenderFlow — 부모 버튼 + 자식 3개 + React.memo 토글, 자식별 렌더 카운트 배지
- GoalViz 4: 리렌더 트리거 · Render→Commit 2단계 · 메모이제이션 이유 · StrictMode

**useState 깊게** (`/stages/stage-5-usestate`)
- BatchUpdate — +3 버튼 2종(함수형·값), 렌더 카운트로 batching 체감
- StaleClosure — 3초 지연 출력, 그 사이에 count 변경하며 함수형 vs 값 비교
- GoalViz 4: batching · lazy init · 함수형 vs 값 · 비동기 동작

**Error Boundary** (`/stages/stage-error-boundary`)
- Explosion — EB 토글 + 자식 throw + 폴백 UI + "다시 시도". EB 없을 때 앱 하얗게 되는 거 시뮬
- GoalViz 4: 잡는 것/못 잡는 것 · react-error-boundary · Suspense 조합 · 복구 UI

## 검증

- `npm run build` ✓ / `npm run lint` ✓
- 28 스테이지 SSG 유지, 4개가 플레이 가능 상태 (useMemo 포함)

## 다음 배치 예고

- Batch 2: useEffect · 커스텀 훅 · useRef (🎣 훅 탭 마무리)
- Batch 3~6: 성능 · 상태 · API · 인프라
