### PR TITLE
✨ Feature: 놀이기구 Batch 2 — useEffect · 커스텀 훅 · useRef (훅 탭 마무리)

### DIFF
--- a/src/components/playgrounds/custom-hooks/GoalViz.tsx
+++ b/src/components/playgrounds/custom-hooks/GoalViz.tsx
@@ -1,0 +1,133 @@
+import { ReactNode } from 'react'
+
+export default function CustomHooksGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          복붙하던 로직을 &quot;내 훅&quot;으로 모으면 코드가 조용해진다.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🔧'
+          title='커스텀 훅 설계 원칙'
+          hook='use로 시작, 훅을 조합, 컴포넌트에서 쓰기 쉽게'
+        >
+          <p>커스텀 훅은 그냥 &quot;함수&quot;야. 세 가지만 지키면 돼.</p>
+          <ol className='mt-2 list-decimal space-y-1 pl-5 text-[13px]'>
+            <li>
+              이름이 <code>use</code>로 시작 (ESLint가 훅 규칙 검사 가능)
+            </li>
+            <li>
+              내부에서 다른 훅 자유롭게 호출 (<code>useState</code>,{' '}
+              <code>useEffect</code>...)
+            </li>
+            <li>
+              바깥에는 <b>최소한의 API</b>만 노출 (값 + 제어 함수 정도)
+            </li>
+          </ol>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🧩'
+          title='HOC vs 커스텀 훅'
+          hook='같은 재사용 문제, 훅이 대부분 승리'
+        >
+          <p>
+            예전엔 <code>withAuth(Component)</code> 같은 HOC(고차 컴포넌트)로
+            로직을 공유했어. 하지만 단점이 많았지.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>❌ HOC: prop 네이밍 충돌, 트리가 깊어짐, 타입이 꼬임</li>
+            <li>✅ 훅: 트리 모양 유지, 반환값 이름 자유, 조합이 자연스러움</li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            💡 규칙: 로직만 공유하고 싶다 → 훅. 렌더 트리 자체를 감싸야 한다 →
+            HOC 또는 Wrapper 컴포넌트.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='📦'
+          title='반환값 최적화 패턴'
+          hook='useCallback·useMemo로 참조 안정 유지'
+        >
+          <p>
+            커스텀 훅이 함수나 객체를 리턴하면, 쓰는 쪽에서 그 값을 다른 훅의
+            deps로 받을 수 있어. 매번 새 참조면 하위 훅이 오동작.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`function useDialog() {
+  const [open, setOpen] = useState(false)
+  // ✅ 함수는 useCallback
+  const show = useCallback(() => setOpen(true), [])
+  const hide = useCallback(() => setOpen(false), [])
+  return { open, show, hide }  // 또는 [open, show, hide] as const
+}`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🎯'
+          title='객체 반환 vs 배열 반환'
+          hook='의미가 같은 값들 = 객체, 순서가 중요 = 배열'
+        >
+          <p>두 스타일 모두 표준적이야. 선택 기준:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              📦 <b>객체</b>: 필드가 많을 때, 쓰는 쪽이 일부만 골라쓸 때 (예:{' '}
+              <code>{`{ data, error, loading }`}</code>)
+            </li>
+            <li>
+              🎢 <b>배열</b>: 2~3개 값을 순서대로 쓸 때, 이름을 자유롭게 주고
+              싶을 때 (<code>{`[value, setValue]`}</code>)
+            </li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            💡 <code>useState</code>·<code>useReducer</code>가 배열을 돌려주는
+            이유 — 이름을 자유롭게 받기 편해서.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/custom-hooks/UseCopyDemo.tsx
+++ b/src/components/playgrounds/custom-hooks/UseCopyDemo.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+// 🎣 커스텀 훅 — 클립보드 복사 + "복사됨" 상태 타이머
+function useCopyToClipboard(
+  resetMs = 2000
+): [boolean, (text: string) => Promise<void>] {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text)
+        setCopied(true)
+        if (timer.current) clearTimeout(timer.current)
+        timer.current = setTimeout(() => setCopied(false), resetMs)
+      } catch {
+        setCopied(false)
+      }
+    },
+    [resetMs]
+  )
+
+  return [copied, copy]
+}
+
+const SAMPLE = `const [copied, copy] = useCopyToClipboard()
+<button onClick={() => copy('hello')}>
+  {copied ? '✅ 복사됨' : '📋 복사'}
+</button>`
+
+export default function UseCopyDemo() {
+  const [copied, copy] = useCopyToClipboard(1500)
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <div className='mb-2 text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+          📋 복사해볼 텍스트
+        </div>
+        <pre className='overflow-x-auto rounded-lg bg-gray-900 p-3 font-mono text-[11px] text-gray-100'>
+          <code>{SAMPLE}</code>
+        </pre>
+        <button
+          type='button'
+          onClick={() => copy(SAMPLE)}
+          className={cn(
+            'mt-3 inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-bold transition',
+            copied
+              ? 'bg-emerald-500 text-white'
+              : 'bg-[#ff5e48] text-white hover:bg-[#ec4b36]'
+          )}
+        >
+          {copied ? '✅ 복사됨!' : '📋 복사하기'}
+        </button>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>커스텀 훅</b>이 은근슬쩍 해준 일:
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>✂️ navigator.clipboard.writeText 호출</li>
+          <li>
+            ⏱️ 성공 시 <code>copied = true</code>로 바꾸고 1.5초 뒤 자동 false
+            복귀 (타이머 관리)
+          </li>
+          <li>
+            🧹 연속 클릭에도 타이머가 꼬이지 않게 clearTimeout으로 이전 타이머
+            정리
+          </li>
+        </ul>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ 컴포넌트 안에 모든 로직',
+          code: `function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => setCopied(false), 2000)
+  }
+
+  return <button onClick={copy}>{copied ? '✅' : '📋'}</button>
+}`,
+          takeaway:
+            '다른 곳에서도 복사 기능 필요하면 이 로직 전부 복붙. 타이머 관리까지 깨짐',
+        }}
+        after={{
+          label: '✅ useCopyToClipboard 훅으로 분리',
+          code: `function useCopyToClipboard(resetMs = 2000) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const copy = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => setCopied(false), resetMs)
+  }, [resetMs])
+
+  return [copied, copy] as const
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, copy] = useCopyToClipboard()
+  return <button onClick={() => copy(text)}>{copied ? '✅' : '📋'}</button>
+}`,
+          takeaway:
+            '로직은 훅에, 표시는 컴포넌트에. 어디서든 두 줄로 끝. 테스트도 편함',
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/playgrounds/custom-hooks/UseDebounceDemo.tsx
+++ b/src/components/playgrounds/custom-hooks/UseDebounceDemo.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+// 🎣 커스텀 훅 — 값이 안정된 뒤 delay ms 후에 반영
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebounced(value)
+    }, delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+  return debounced
+}
+
+export default function UseDebounceDemo() {
+  const [query, setQuery] = useState('')
+  const [delay, setDelay] = useState(500)
+  const debounced = useDebounce(query, delay)
+  const [apiCalls, setApiCalls] = useState(0)
+
+  useEffect(() => {
+    if (!debounced) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setApiCalls((n) => n + 1)
+  }, [debounced])
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <label className='mb-2 block text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+          ⌨️ 입력 (매 키 입력마다 state 업데이트)
+        </label>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder='여기에 빠르게 타이핑...'
+          className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 font-mono text-sm focus:border-[#ff5e48] focus:outline-none'
+        />
+        <div className='mt-3 flex items-center gap-2 text-xs text-gray-600'>
+          <span>debounce 딜레이:</span>
+          <input
+            type='range'
+            min={100}
+            max={1500}
+            step={50}
+            value={delay}
+            onChange={(e) => setDelay(Number(e.target.value))}
+            className='flex-1'
+          />
+          <span className='font-mono'>{delay}ms</span>
+        </div>
+      </div>
+
+      <div className='mb-4 grid grid-cols-3 gap-3 rounded-xl bg-white p-4 shadow-sm'>
+        <Stat label='🎤 즉시값 (query)' value={query || '—'} />
+        <Stat label='⏱️ 지연값 (debounced)' value={debounced || '—'} />
+        <Stat label='📞 API 호출 시뮬 횟수' value={apiCalls} />
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 빠르게 타이핑하는 동안 즉시값은 계속 바뀌지만,
+          지연값은 <b>타이핑을 멈춘 뒤 {delay}ms</b> 후에 한 번만 업데이트돼.
+        </p>
+        <p className='mt-2'>
+          만약 즉시값을 그대로 API 파라미터로 썼다면 키 입력마다 요청이 튀었을
+          거야. debounce 덕분에 네트워크는 조용해.
+        </p>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ debounce 없이',
+          code: `function Search() {
+  const [q, setQ] = useState('')
+
+  useEffect(() => {
+    if (q) fetch('/search?q=' + q) // 키마다 한 번씩
+  }, [q])
+
+  return <input value={q} onChange={e => setQ(e.target.value)} />
+}`,
+          takeaway: '키 입력 10번 = fetch 10번. 서버에도 사용자에게도 낭비',
+        }}
+        after={{
+          label: '✅ useDebounce 커스텀 훅',
+          code: `function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)  // 새 입력 오면 이전 타이머 취소
+  }, [value, delay])
+  return debounced
+}
+
+function Search() {
+  const [q, setQ] = useState('')
+  const debounced = useDebounce(q, 400)
+  useEffect(() => { if (debounced) fetch('/search?q=' + debounced) }, [debounced])
+  return <input value={q} onChange={e => setQ(e.target.value)} />
+}`,
+          takeaway:
+            '타이핑이 400ms 이상 멈춘 뒤에만 fetch 한 번. 로직 재사용도 깔끔',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 커스텀 훅의 핵심
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 <b>이름이 use로 시작</b>해야 리액트가 훅으로 인식. 내부에서 다른
+            훅을 자유롭게 조합.
+          </li>
+          <li>
+            🎯 여러 컴포넌트에서 <b>똑같은 로직을 복붙</b>하고 있다면 그게
+            커스텀 훅 후보.
+          </li>
+          <li>
+            🎯 훅 로직은 &quot;블랙박스&quot;처럼 감춰지지만, 내부에서 여전히{' '}
+            <code>useState</code>·<code>useEffect</code>를 쓰니까 규칙 (조건문
+            안에서 호출 금지 등)은 그대로 지켜야 해.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        {label}
+      </div>
+      <div className='mt-0.5 font-mono text-sm font-bold break-all'>
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/custom-hooks/index.tsx
+++ b/src/components/playgrounds/custom-hooks/index.tsx
@@ -1,0 +1,47 @@
+import GoalViz from './GoalViz'
+import UseCopyDemo from './UseCopyDemo'
+import UseDebounceDemo from './UseDebounceDemo'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function CustomHooksPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              내가 자주 쓰는 로직, 훅으로 모아두자
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              두 놀이기구 모두 <b>실무에서 매일 쓰는 훅</b>이야. 먼저 직접
+              사용해보고, 그 뒤에 훅이 내부에서 뭘 해줬는지 코드로 확인하자.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='⏱️'
+        title='useDebounce — 값이 안정된 뒤 반영'
+        description='빠르게 타이핑하면 즉시값은 매번 바뀌지만, 지연값은 멈춘 뒤 한 번만 업데이트. API 호출 절약의 기본.'
+      >
+        <UseDebounceDemo />
+      </PlaygroundSection>
+
+      <PlaygroundSection
+        index='B'
+        emoji='📋'
+        title='useCopyToClipboard — 복사 상태 자동 리셋'
+        description='클립보드 복사 + "복사됨" 표시 + 타이머 자동 리셋을 훅 하나로. 쓰는 쪽은 두 줄이면 끝.'
+      >
+        <UseCopyDemo />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/useeffect/CleanupLab.tsx
+++ b/src/components/playgrounds/useeffect/CleanupLab.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+function Ticker({ cleanup, onTick }: { cleanup: boolean; onTick: () => void }) {
+  const [seconds, setSeconds] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setSeconds((s) => s + 1)
+      onTick()
+    }, 1000)
+
+    return cleanup
+      ? () => {
+          clearInterval(id)
+        }
+      : undefined
+    // onTick은 의도적으로 deps에서 제외 (매 렌더 새 함수라 무한 재시작 방지)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cleanup])
+
+  return (
+    <div className='rounded-xl bg-emerald-50 p-5 text-center ring-1 ring-emerald-200'>
+      <div className='mb-1 text-3xl'>⏱️</div>
+      <div className='font-bold text-emerald-800'>Ticker 가동 중</div>
+      <div className='mt-2 font-mono text-4xl font-extrabold text-emerald-900'>
+        {seconds}s
+      </div>
+      <div className='mt-1 text-xs text-emerald-700'>
+        cleanup: {cleanup ? '✅ 켜짐' : '❌ 꺼짐'}
+      </div>
+    </div>
+  )
+}
+
+export default function CleanupLab() {
+  const [mounted, setMounted] = useState(true)
+  const [cleanup, setCleanup] = useState(true)
+  const [totalTicks, setTotalTicks] = useState(0)
+  const [resetKey, setResetKey] = useState(0)
+
+  const handleRemount = () => {
+    setMounted(false)
+    setTimeout(() => {
+      setMounted(true)
+      setResetKey((k) => k + 1)
+    }, 200)
+  }
+
+  const handleReset = () => {
+    setTotalTicks(0)
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setMounted((m) => !m)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            mounted
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          {mounted ? '🟢 Ticker 마운트됨' : '⚪ Ticker 언마운트됨'}
+        </button>
+        <button
+          type='button'
+          onClick={() => setCleanup((c) => !c)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            cleanup
+              ? 'bg-emerald-500 text-white'
+              : 'border border-red-300 bg-white text-red-600'
+          )}
+        >
+          {cleanup ? '✅ cleanup 반환' : '❌ cleanup 없음'}
+        </button>
+        <button
+          type='button'
+          onClick={handleRemount}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🔄 remount
+        </button>
+        <button
+          type='button'
+          onClick={handleReset}
+          className='rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-600 hover:border-gray-300'
+        >
+          ↺ 카운트 리셋
+        </button>
+      </div>
+
+      <div className='mb-4 grid grid-cols-2 gap-3 rounded-xl bg-white p-4 shadow-sm'>
+        <div>
+          <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+            🔔 전체 tick 횟수
+          </div>
+          <div className='mt-0.5 font-mono text-3xl font-extrabold'>
+            {totalTicks}
+          </div>
+        </div>
+        <div className='text-xs text-gray-600'>
+          {cleanup ? (
+            <p>
+              ✅ cleanup이 제대로 돌면 언마운트 시 interval이 <b>멈춰</b>. Tick
+              횟수가 안 늘어나.
+            </p>
+          ) : (
+            <p>
+              ❌ cleanup 없이 Ticker를 언마운트하면 interval이 <b>살아남아</b>{' '}
+              백그라운드에서 계속 tick. 전체 카운트가 계속 증가함.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className='mb-4 min-h-[140px]'>
+        {mounted ? (
+          <Ticker
+            key={resetKey}
+            cleanup={cleanup}
+            onTick={() => setTotalTicks((t) => t + 1)}
+          />
+        ) : (
+          <div className='rounded-xl border-2 border-dashed border-gray-200 bg-white p-8 text-center text-gray-400'>
+            Ticker가 언마운트된 상태 — 전체 tick 카운트를 지켜봐
+          </div>
+        )}
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ cleanup 없음',
+          code: `useEffect(() => {
+  const id = setInterval(tick, 1000)
+  // cleanup을 반환 안 하면?
+}, [])`,
+          takeaway:
+            '컴포넌트가 사라져도 interval은 계속 돌고 메모리도 안 풀림. 수십 번 마운트/언마운트 반복하면 리크',
+        }}
+        after={{
+          label: '✅ cleanup 반환',
+          code: `useEffect(() => {
+  const id = setInterval(tick, 1000)
+  return () => clearInterval(id)  // 언마운트 때 정리
+}, [])`,
+          takeaway:
+            '언마운트·deps 변경 시 자동으로 clearInterval 호출 → 깨끗한 cleanup',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 cleanup이 필요한 상황
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>🎯 setInterval · setTimeout — clear로 정리</li>
+          <li>
+            🎯 <code>addEventListener</code> — 같은 이름으로 removeEventListener
+          </li>
+          <li>🎯 WebSocket · EventSource — close()</li>
+          <li>🎯 fetch 요청 — AbortController로 취소 (다음 놀이기구 참고)</li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/useeffect/GoalViz.tsx
+++ b/src/components/playgrounds/useeffect/GoalViz.tsx
@@ -1,0 +1,132 @@
+import { ReactNode } from 'react'
+
+export default function UseEffectGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          useEffect는 &quot;모든 것&quot;이 아니라 &quot;외부 세계와
+          동기화&quot;의 훅.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🎭'
+          title='생명주기 대체가 아니다'
+          hook='"mount 때 이거 해라"가 아니라 "이 상태와 바깥 세상을 맞춰라"'
+        >
+          <p>
+            예전 클래스 컴포넌트의 <code>componentDidMount</code>·
+            <code>componentWillUnmount</code>를 직접 대응시키려 하면 대부분
+            버그.
+          </p>
+          <p>
+            useEffect의 진짜 질문은 &quot;이 값들이 바뀔 때마다, 외부 세계(DOM,
+            타이머, 서버)를 어떻게 따라가게 할까?&quot;야.
+          </p>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 deps 배열에 들어간 값들이 바뀌면 cleanup → 재실행. 매
+            &quot;동기화 사이클&quot;마다.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='📋'
+          title='의존성 배열의 진짜 의미'
+          hook='ESLint 시키는 대로 다 넣어라, 진짜로'
+        >
+          <p>
+            deps에 빠뜨린 값이 있으면 effect가 오래된 값으로 동작 (Stale
+            Closure와 같은 원리).
+          </p>
+          <p className='mt-2'>
+            &quot;너무 자주 실행된다&quot; 싶으면 deps에서 빼지 말고{' '}
+            <b>왜 자주 바뀌는지를 고쳐</b>야 해 (useMemo/useCallback).
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// ❌ user를 빠뜨림
+useEffect(() => log(user), [])
+
+// ✅ 정직하게 다 넣기
+useEffect(() => log(user), [user])`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🧹'
+          title='Cleanup 함수의 역할'
+          hook='effect가 남긴 흔적을 치우는 청소부'
+        >
+          <p>
+            effect가 setInterval, addEventListener, WebSocket 같은 &quot;외부
+            자원&quot;을 열었다면 반드시 닫아줘야 해. 안 그러면 언마운트 후에도
+            계속 살아서 메모리 누수·버그 원인.
+          </p>
+          <p className='mt-2'>
+            cleanup은 <b>언마운트 시</b>는 물론 <b>deps가 바뀔 때도</b> 돌아.
+            &quot;다시 동기화하기 전에 이전 상태 정리&quot; 순서라고 보면 돼.
+          </p>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 놀이기구 A에서 cleanup 토글 껐다 켰다 해봐.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🏁'
+          title='Race Condition & 안 써도 되는 경우'
+          hook='비동기는 가드. 그리고 useEffect 남발 금지'
+        >
+          <p>
+            데이터 페칭은 race condition 주의. 새 요청이 시작될 때 이전
+            요청/결과를 무효화해야 해 (AbortController + cancelled flag).
+          </p>
+          <p className='mt-2'>
+            또 <b>렌더 중 계산</b>·<b>이벤트 핸들러</b>·<b>파생 상태</b>로 풀 수
+            있는 문제를 굳이 useEffect로 끌어오지 마. 그건 과한 쓰임.
+          </p>
+          <p className='mt-3 rounded-lg bg-amber-50 p-2 text-[12px] text-amber-900'>
+            ⚠️ &quot;useEffect 없이 풀 수 있나?&quot; 한 번 더 물어보자
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/useeffect/RaceCondition.tsx
+++ b/src/components/playgrounds/useeffect/RaceCondition.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+// 가짜 검색: 랜덤 딜레이 후 응답
+async function fakeSearch(
+  query: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const delay = 400 + Math.floor(Math.random() * 1400)
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve(`"${query}" (${delay}ms)`), delay)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new DOMException('aborted', 'AbortError'))
+    })
+  })
+}
+
+export default function RaceCondition() {
+  const [query, setQuery] = useState('')
+  const [result, setResult] = useState<string>('')
+  const [guard, setGuard] = useState(true)
+  const [pending, setPending] = useState(0)
+
+  useEffect(() => {
+    if (!query) {
+      // 빈 쿼리 → 이전 결과 초기화
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setResult('')
+      return
+    }
+    let cancelled = false
+    const controller = new AbortController()
+    setPending((p) => p + 1)
+
+    fakeSearch(query, guard ? controller.signal : undefined)
+      .then((res) => {
+        if (guard && cancelled) return
+        setResult(res)
+      })
+      .catch(() => {
+        // aborted — 무시
+      })
+      .finally(() => {
+        setPending((p) => Math.max(0, p - 1))
+      })
+
+    return () => {
+      cancelled = true
+      if (guard) controller.abort()
+    }
+  }, [query, guard])
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setGuard((g) => !g)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            guard
+              ? 'bg-emerald-500 text-white'
+              : 'border border-red-300 bg-white text-red-600'
+          )}
+        >
+          {guard ? '✅ Race 가드 켜짐' : '❌ Race 가드 꺼짐'}
+        </button>
+        <span className='text-xs text-gray-500'>
+          가드 끄고 빠르게 타이핑해봐 — 옛날 응답이 최신을 덮는다
+        </span>
+      </div>
+
+      <div className='mb-3 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <label className='mb-2 block text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+          🔎 검색 (응답에 400~1800ms 랜덤 딜레이)
+        </label>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder='react, useMemo, suspense...'
+          className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 font-mono text-sm focus:border-[#ff5e48] focus:outline-none'
+        />
+        <div className='mt-3 grid grid-cols-2 gap-3 text-sm'>
+          <div>
+            <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+              ⏳ 진행 중
+            </div>
+            <div className='mt-0.5 font-mono text-lg font-bold'>{pending}</div>
+          </div>
+          <div>
+            <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+              🪧 표시된 결과
+            </div>
+            <div className='mt-0.5 font-mono text-sm font-bold break-all'>
+              {result || '—'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: query를 빠르게 &quot;r&quot; → &quot;re&quot; →
+          &quot;rea&quot; → &quot;react&quot;로 타이핑.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            ❌ <b>가드 OFF</b>: 늦게 도착한 &quot;r&quot; 응답이
+            &quot;react&quot; 결과를 <b>덮어쓸 수 있어</b>. 실제 앱에서는
+            사용자가 &quot;왜 예전 검색 결과가 뜨지&quot; 하는 순간.
+          </li>
+          <li>
+            ✅ <b>가드 ON</b>: 새 입력이 들어올 때 이전 요청을{' '}
+            <code>AbortController</code>로 취소 + cancelled 플래그로 setResult
+            차단. 가장 최신 쿼리 응답만 반영.
+          </li>
+        </ul>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ Race Condition 취약',
+          code: `useEffect(() => {
+  fetch(\`/search?q=\${query}\`)
+    .then(r => r.json())
+    .then(setResult)  // 늦게 온 응답이 최신을 덮을 수 있음
+}, [query])`,
+          takeaway:
+            '네트워크가 불안정하거나 사용자가 빠르게 타이핑하면 옛날 응답이 최신을 밀어냄',
+        }}
+        after={{
+          label: '✅ cancelled + AbortController',
+          code: `useEffect(() => {
+  let cancelled = false
+  const controller = new AbortController()
+
+  fetch(\`/search?q=\${query}\`, { signal: controller.signal })
+    .then(r => r.json())
+    .then(data => { if (!cancelled) setResult(data) })
+
+  return () => {
+    cancelled = true
+    controller.abort()
+  }
+}, [query])`,
+          takeaway:
+            '새 요청이 시작될 때 이전 effect의 cleanup이 먼저 돌면서 flag + abort로 옛 응답 차단',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 Race Condition은 언제 생기나
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>🎯 검색창 / 자동완성 — 타이핑이 네트워크보다 빠를 때</li>
+          <li>🎯 상세 페이지 이동 직후 이전 페이지 fetch가 늦게 도착</li>
+          <li>
+            🎯 무한 스크롤 페이징 — 페이지 빠르게 넘기면 옛 페이지 응답이 뒤엉킴
+          </li>
+          <li className='pt-2 text-[12px] text-gray-500'>
+            💡 실전에서 TanStack Query를 쓰는 이유 중 하나가 이 가드를
+            프레임워크 레벨에서 자동화해주기 때문이야.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/useeffect/index.tsx
+++ b/src/components/playgrounds/useeffect/index.tsx
@@ -1,0 +1,48 @@
+import CleanupLab from './CleanupLab'
+import GoalViz from './GoalViz'
+import RaceCondition from './RaceCondition'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseEffectPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              두 놀이기구 다 cleanup 켰다 껐다 해봐
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              useEffect에서 가장 실수하는 포인트가 cleanup 누락. 메모리 누수와
+              race condition을 실제로 재현해보면서 왜 cleanup이 곧 안전장치인지
+              체감해보자.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🧹'
+        title='Cleanup 실험실 (메모리 누수)'
+        description='setInterval을 띄우고 언마운트. cleanup 없으면 죽은 자식 뒤에서도 tick이 계속 카운트된다.'
+      >
+        <CleanupLab />
+      </PlaygroundSection>
+
+      <PlaygroundSection
+        index='B'
+        emoji='🏁'
+        title='Race Condition 디버깅'
+        description='검색창에 랜덤 딜레이 응답. 가드 없으면 옛날 응답이 최신을 덮어쓴다. AbortController + cancelled 플래그로 해결.'
+      >
+        <RaceCondition />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/useref/FocusDemo.tsx
+++ b/src/components/playgrounds/useref/FocusDemo.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+export default function FocusDemo() {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [scrollCount, setScrollCount] = useState(0)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const focusInput = () => inputRef.current?.focus()
+  const selectInput = () => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }
+  const scrollToTop = () => {
+    scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+    setScrollCount((c) => c + 1)
+  }
+  const scrollToBottom = () => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current?.scrollHeight,
+      behavior: 'smooth',
+    })
+    setScrollCount((c) => c + 1)
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <label className='mb-2 block text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+          🎯 DOM ref로 input 포커스
+        </label>
+        <input
+          ref={inputRef}
+          defaultValue='hello useRef'
+          className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 font-mono text-sm focus:border-[#ff5e48] focus:outline-none'
+        />
+        <div className='mt-3 flex flex-wrap gap-2'>
+          <button
+            type='button'
+            onClick={focusInput}
+            className='rounded-full bg-[#ff5e48] px-4 py-1.5 text-sm font-bold text-white hover:bg-[#ec4b36]'
+          >
+            🎯 포커스
+          </button>
+          <button
+            type='button'
+            onClick={selectInput}
+            className='rounded-full border border-gray-300 bg-white px-4 py-1.5 text-sm font-bold text-gray-700 hover:border-[#ff5e48]'
+          >
+            ✂️ 포커스 + 전체 선택
+          </button>
+        </div>
+      </div>
+
+      <div className='mb-4 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <div className='mb-2 flex items-center justify-between'>
+          <span className='text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+            📜 스크롤 컨테이너 (ref로 제어)
+          </span>
+          <span className='font-mono text-xs text-gray-500'>
+            scroll 버튼 누름: {scrollCount}
+          </span>
+        </div>
+        <div
+          ref={scrollRef}
+          className='h-32 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3 font-mono text-xs'
+        >
+          {Array.from({ length: 40 }, (_, i) => (
+            <div key={i}>line {i + 1}</div>
+          ))}
+        </div>
+        <div className='mt-3 flex gap-2'>
+          <button
+            type='button'
+            onClick={scrollToTop}
+            className='rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-bold text-gray-700 hover:border-[#ff5e48]'
+          >
+            ⬆️ top
+          </button>
+          <button
+            type='button'
+            onClick={scrollToBottom}
+            className='rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-bold text-gray-700 hover:border-[#ff5e48]'
+          >
+            ⬇️ bottom
+          </button>
+        </div>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 버튼을 아무리 눌러도 이 컴포넌트는{' '}
+          <b>리렌더되지 않아</b> (scroll 버튼은 별개 카운트 state라 리렌더됨).
+        </p>
+        <p className='mt-2'>
+          useRef는 &quot;렌더와 무관한 저장소&quot; + &quot;DOM 조작용
+          포인터&quot;. 값이 바뀌어도 렌더 트리거 없음.
+        </p>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ state로 DOM 조작',
+          code: `const [shouldFocus, setShouldFocus] = useState(false)
+
+useEffect(() => {
+  if (shouldFocus) {
+    document.querySelector('input')?.focus()  // 🚫 불안정
+    setShouldFocus(false)
+  }
+}, [shouldFocus])
+
+<button onClick={() => setShouldFocus(true)}>포커스</button>`,
+          takeaway:
+            'state flag + querySelector로 우회 → 불필요한 리렌더 + 선택자 바뀌면 깨짐',
+        }}
+        after={{
+          label: '✅ useRef + ref prop',
+          code: `const inputRef = useRef<HTMLInputElement>(null)
+
+<input ref={inputRef} />
+<button onClick={() => inputRef.current?.focus()}>포커스</button>`,
+          takeaway:
+            '리액트가 직접 DOM 노드를 넘겨줌. state 변경·리렌더 없이 그 순간 조작',
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/playgrounds/useref/GoalViz.tsx
+++ b/src/components/playgrounds/useref/GoalViz.tsx
@@ -1,0 +1,136 @@
+import { ReactNode } from 'react'
+
+export default function UseRefGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          렌더와 무관한 저장소, 그리고 DOM으로 가는 통로.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🎭'
+          title='useRef의 2가지 용도'
+          hook='DOM 접근 / 렌더와 무관한 값 저장'
+        >
+          <p>
+            리액트에서 useRef는 사실 <b>같은 도구의 두 가지 쓰임</b>이야.
+          </p>
+          <ol className='mt-2 list-decimal space-y-1 pl-5 text-[13px]'>
+            <li>
+              <b>DOM 노드 참조</b>: <code>{'<input ref={myRef} />'}</code> —
+              리액트가 마운트 후 current에 실제 DOM을 넣어줌. focus·scroll·측정.
+            </li>
+            <li>
+              <b>값 저장 (mutable container)</b>: 타이머 id, 이전 값, 외부 구독
+              id처럼 <b>화면에 표시하진 않지만 렌더 사이에 기억해야 할</b> 값.
+            </li>
+          </ol>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='⚖️'
+          title='useState와 뭐가 다른가'
+          hook='값 바뀌어도 리렌더 안 한다'
+        >
+          <p>
+            가장 큰 차이는 &quot;리렌더 트리거 여부&quot;. useState는 바꾸면
+            다시 그려져. useRef는 <code>current</code>를 바꿔도{' '}
+            <b>리렌더 안 됨</b>.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// 리렌더됨
+const [n, setN] = useState(0)
+setN(1)  // 즉시 리렌더
+
+// 리렌더 안 됨
+const ref = useRef(0)
+ref.current = 1  // 조용히 바뀜`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            👉 화면에 &quot;보여야&quot; 하는 값이면 state, 아니면 ref.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🤝'
+          title='forwardRef 패턴'
+          hook='자식 컴포넌트의 DOM을 부모가 제어'
+        >
+          <p>
+            커스텀 컴포넌트에 ref를 넘기려면 <code>forwardRef</code>로 감싸야
+            했어 (React 19부터는 일부 경우 생략 가능).
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const FancyInput = forwardRef<HTMLInputElement, Props>(
+  (props, ref) => <input ref={ref} {...props} />
+)
+
+// 부모
+const inputRef = useRef<HTMLInputElement>(null)
+<FancyInput ref={inputRef} />
+<button onClick={() => inputRef.current?.focus()}>포커스</button>`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='⚠️'
+          title='렌더 중에는 읽지도 쓰지도 말기'
+          hook='"커밋 이후"가 ref의 무대'
+        >
+          <p>
+            리액트의 동시성 렌더링에서 ref는 <b>커밋 이후에만 안정</b>해. 렌더
+            중 ref.current를 바꾸면 결과가 꼬일 수 있어.
+          </p>
+          <p className='mt-2'>
+            규칙: <b>event handler</b>, <b>useEffect</b>, <b>useLayoutEffect</b>{' '}
+            안에서 읽고 써라. 렌더 본문에서 조작하지 말 것.
+          </p>
+          <p className='mt-3 rounded-lg bg-amber-50 p-2 text-[12px] text-amber-900'>
+            ⚠️ 놀이기구 예제에 렌더 중 ref 접근이 있지만 그건 교육용 의도 —
+            ESLint도 경고.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/useref/PreviousDemo.tsx
+++ b/src/components/playgrounds/useref/PreviousDemo.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+// 🎣 usePrevious 커스텀 훅
+// 의도된 "렌더 중 ref 읽기" — 이 패턴 자체가 학습 포인트
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined)
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  // eslint-disable-next-line react-hooks/refs
+  return ref.current
+}
+
+export default function PreviousDemo() {
+  const [count, setCount] = useState(0)
+  const prev = usePrevious(count)
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 grid grid-cols-2 gap-3 rounded-xl bg-white p-4 shadow-sm'>
+        <div className='text-center'>
+          <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+            🕓 이전 count
+          </div>
+          <div className='mt-0.5 font-mono text-4xl font-extrabold text-gray-400'>
+            {prev ?? '—'}
+          </div>
+        </div>
+        <div className='text-center'>
+          <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+            🟢 지금 count
+          </div>
+          <div className='mt-0.5 font-mono text-4xl font-extrabold text-emerald-600'>
+            {count}
+          </div>
+        </div>
+      </div>
+
+      <div className='mb-4 flex flex-wrap gap-2'>
+        <button
+          type='button'
+          onClick={() => setCount((c) => c + 1)}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          ➕ 올리기
+        </button>
+        <button
+          type='button'
+          onClick={() => setCount((c) => c - 1)}
+          className='rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-bold text-gray-700 hover:border-[#ff5e48]'
+        >
+          ➖ 내리기
+        </button>
+        <button
+          type='button'
+          onClick={() => setCount(0)}
+          className='rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-600 hover:border-gray-300'
+        >
+          ↺ 0
+        </button>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 버튼을 눌러 count를 바꿔봐. &quot;이전&quot;과
+          &quot;지금&quot;이 한 칸씩 미끄러지는 걸 볼 수 있어.
+        </p>
+        <p className='mt-2'>
+          원리는 간단해. <code>useEffect</code>는 커밋 뒤에 실행되니까 ref는
+          &quot;한 박자 늦게&quot; 갱신돼. 즉 렌더 중에 읽으면 <b>이전 값</b>
+          이야.
+        </p>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ state로 이전 값을 저장하면',
+          code: `const [count, setCount] = useState(0)
+const [prev, setPrev] = useState(0)
+
+const increase = () => {
+  setPrev(count)       // 리렌더 1
+  setCount(c => c + 1) // 리렌더 2
+}`,
+          takeaway:
+            '별도 state를 써서 setState 두 번 호출 → 2회 리렌더, 순서 꼬이기 쉬움',
+        }}
+        after={{
+          label: '✅ useRef + useEffect로 usePrevious',
+          code: `function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined)
+  useEffect(() => {
+    ref.current = value  // 커밋 이후 업데이트
+  }, [value])
+  return ref.current     // 렌더 중엔 '이전' 값
+}
+
+function Counter() {
+  const [count, setCount] = useState(0)
+  const prev = usePrevious(count)
+  return <div>이전: {prev} · 지금: {count}</div>
+}`,
+          takeaway:
+            '렌더 트리거 없이 이전 값을 기억. 재사용 가능한 훅으로 떨어뜨림',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 useRef vs useState 핵심 차이
+        </div>
+        <table className='w-full text-xs'>
+          <thead>
+            <tr className='border-b border-gray-200 text-left text-gray-500'>
+              <th className='py-1 pr-2'></th>
+              <th className='py-1 pr-2'>useState</th>
+              <th className='py-1'>useRef</th>
+            </tr>
+          </thead>
+          <tbody className='text-gray-700'>
+            <tr className='border-b border-gray-100'>
+              <td className='py-1.5 pr-2 font-semibold'>값 바뀌면 리렌더?</td>
+              <td className='py-1.5 pr-2'>✅ 예</td>
+              <td className='py-1.5'>❌ 아니오</td>
+            </tr>
+            <tr className='border-b border-gray-100'>
+              <td className='py-1.5 pr-2 font-semibold'>렌더에 반영?</td>
+              <td className='py-1.5 pr-2'>✅ 즉시</td>
+              <td className='py-1.5'>⏳ 다음 렌더 이후</td>
+            </tr>
+            <tr>
+              <td className='py-1.5 pr-2 font-semibold'>주요 용도</td>
+              <td className='py-1.5 pr-2'>화면에 보여줄 값</td>
+              <td className='py-1.5'>DOM 참조 · 타이머 id · 이전 값</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/useref/index.tsx
+++ b/src/components/playgrounds/useref/index.tsx
@@ -1,0 +1,47 @@
+import FocusDemo from './FocusDemo'
+import GoalViz from './GoalViz'
+import PreviousDemo from './PreviousDemo'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseRefPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              ref는 &quot;리렌더 없이&quot;가 매력
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              첫 놀이기구에서 DOM에 직접 닿는 경험, 두 번째에서 렌더와 무관한 값
+              저장소로서의 쓰임을 확인하자.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🎯'
+        title='DOM 직접 조작 (포커스 · 스크롤)'
+        description='input에 포커스, 컨테이너 스크롤을 ref로 직접. state 없이도 리액트가 DOM을 넘겨준다.'
+      >
+        <FocusDemo />
+      </PlaygroundSection>
+
+      <PlaygroundSection
+        index='B'
+        emoji='🕓'
+        title='usePrevious — 이전 값 추적'
+        description='useRef + useEffect 조합으로 "한 박자 늦게" 갱신되는 저장소. 렌더와 무관한 값 저장소로서의 ref.'
+      >
+        <PreviousDemo />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/data/playgrounds.ts
+++ b/src/data/playgrounds.ts
@@ -2,12 +2,18 @@ import type { ComponentType } from 'react'
 import UseMemoPlayground from '@/components/playgrounds/usememo'
 import RenderingPlayground from '@/components/playgrounds/rendering'
 import UseStatePlayground from '@/components/playgrounds/usestate'
+import UseEffectPlayground from '@/components/playgrounds/useeffect'
+import CustomHooksPlayground from '@/components/playgrounds/custom-hooks'
+import UseRefPlayground from '@/components/playgrounds/useref'
 import ErrorBoundaryPlayground from '@/components/playgrounds/error-boundary'
 
 export const playgrounds: Record<string, ComponentType> = {
   'stage-1-rendering': RenderingPlayground,
   'stage-2-usememo': UseMemoPlayground,
   'stage-5-usestate': UseStatePlayground,
+  'stage-6-useeffect': UseEffectPlayground,
+  'stage-7-custom-hooks': CustomHooksPlayground,
+  'stage-8-useref': UseRefPlayground,
   'stage-error-boundary': ErrorBoundaryPlayground,
 }
 


### PR DESCRIPTION
closes #17

🎣 훅 탭 6개 중 남은 3개 — useMemo 품질로 일관 적용. 이제 훅 탭 **6/6 플레이 가능**.

## 스테이지별

**useEffect 깊게** (`/stages/stage-6-useeffect`)
- CleanupLab — Ticker 마운트/언마운트 토글, cleanup 유무로 메모리 누수 재현
- RaceCondition — 랜덤 딜레이 fakeSearch + AbortController + cancelled 가드
- GoalViz 4: 생명주기 아님 / deps 정직 / cleanup / race & 안 써도 되는 경우

**커스텀 훅** (`/stages/stage-7-custom-hooks`)
- UseDebounceDemo — 직접 만든 useDebounce + 딜레이 슬라이더 + API 호출 절약 시각화
- UseCopyDemo — useCopyToClipboard + "복사됨" 자동 리셋
- GoalViz 4: 설계 원칙 / HOC vs 훅 / 반환값 최적화 / 객체 vs 배열

**useRef** (`/stages/stage-8-useref`)
- FocusDemo — DOM ref로 포커스·선택·스크롤. 리렌더 없이 조작
- PreviousDemo — usePrevious + useState vs useRef 차이 표
- GoalViz 4: 두 가지 용도 / useState 차이 / forwardRef / 렌더 중 접근 금지

## 검증

- `npm run build` ✓ / `npm run lint` ✓
- 28 스테이지 SSG 유지, 7개가 플레이 가능 (🎣 훅 탭 완전 정복)

## 다음 배치

Batch 3 — ⚡ 성능 탭 (useCallback · React.memo · React Compiler · BOSS · 성능 심화)
