### PR TITLE
✨ Feature: 성능 탭 5개 + Active/뱃지 자동화

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,8 @@
 import Dashboard from '@/components/quest/Dashboard'
 import Legend from '@/components/quest/Legend'
 import QuestTabs from '@/components/quest/QuestTabs'
-import Achievement from '@/components/quest/Achievement'
+import AchievementGrid from '@/components/quest/Achievement'
 import { isCategoryId } from '@/data/stages'
-import { achievements } from '@/data/achievements'
 
 type HomeProps = {
   searchParams: Promise<{ tab?: string }>
@@ -33,13 +32,11 @@ export default async function Home({ searchParams }: HomeProps) {
       <section className='mb-12'>
         <header className='mb-6 border-b-2 border-gray-100 pb-4'>
           <h2 className='mb-1 text-2xl font-extrabold'>🏆 획득 뱃지</h2>
-          <p className='text-sm text-gray-500'>스테이지를 깨면 해금됩니다</p>
+          <p className='text-sm text-gray-500'>
+            스테이지를 깨면 자동으로 해금됩니다
+          </p>
         </header>
-        <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-6'>
-          {achievements.map((a) => (
-            <Achievement key={a.id} achievement={a} />
-          ))}
-        </div>
+        <AchievementGrid />
       </section>
     </div>
   )

--- a/src/components/playgrounds/boss-rendering/BossMission.tsx
+++ b/src/components/playgrounds/boss-rendering/BossMission.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+const ITEM_COUNT = 500
+
+type Item = { id: number; name: string; price: number }
+
+function BareRow({ item }: { item: Item }) {
+  return (
+    <div className='flex items-center justify-between rounded-md bg-white px-3 py-2 text-xs ring-1 ring-gray-100'>
+      <span className='font-mono text-gray-600'>#{item.id}</span>
+      <span className='flex-1 px-2'>{item.name}</span>
+      <span className='font-mono font-bold'>₩{item.price}</span>
+    </div>
+  )
+}
+
+const MemoRow = memo(BareRow)
+
+export default function BossMission() {
+  const [optimized, setOptimized] = useState(false)
+  const [bump, setBump] = useState(0)
+  const [lastMs, setLastMs] = useState<number | null>(null)
+
+  const dataFresh: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+    id: i + 1,
+    name: `아이템 ${i + 1}`,
+    price: 1000 + i * 13,
+  }))
+  const dataStable = useMemo<Item[]>(
+    () =>
+      Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        id: i + 1,
+        name: `아이템 ${i + 1}`,
+        price: 1000 + i * 13,
+      })),
+    []
+  )
+  const data = optimized ? dataStable : dataFresh
+  const RowComp = optimized ? MemoRow : BareRow
+
+  const startRef = useRef<number>(0)
+  // 렌더 타이밍 측정: 버튼 핸들러에서 시작점, effect에서 끝점.
+  // deps 없이 매 렌더 후 실행되어야 하는 의도된 setState.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (startRef.current > 0) {
+      const elapsed = performance.now() - startRef.current
+      setLastMs(Math.round(elapsed))
+      startRef.current = 0
+    }
+  })
+
+  const measuredBump = () => {
+    startRef.current = performance.now()
+    setBump((b) => b + 1)
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={measuredBump}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🎲 부모 리렌더 (무관한 state) {bump}
+        </button>
+        <button
+          type='button'
+          onClick={() => setOptimized((v) => !v)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            optimized
+              ? 'bg-emerald-500 text-white'
+              : 'border border-red-300 bg-white text-red-600'
+          )}
+        >
+          {optimized ? '✅ 최적화 모드' : '🧨 기본 모드'}
+        </button>
+      </div>
+
+      <div className='mb-4 grid grid-cols-3 gap-3 rounded-xl bg-white p-4 shadow-sm'>
+        <Stat label='📋 아이템 수' value={ITEM_COUNT} />
+        <Stat label='🔁 리렌더 트리거' value={bump} />
+        <Stat
+          label='⏱ 마지막 렌더'
+          value={lastMs === null ? '—' : `${lastMs}ms`}
+        />
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>미션 1</b>: 500개 아이템을 그리는 리스트야. 기본 모드에서{' '}
+          <b>🎲 부모 리렌더 버튼을 연타</b>해 느낌을 확인해.
+        </p>
+        <p className='mt-2'>
+          🎯 <b>미션 2</b>: <b>최적화 모드로 전환</b>하고 같은 버튼을 눌러봐.
+          어떤 게 바뀌는지 (lastMs · 체감) 비교.
+        </p>
+        <p className='mt-2 text-[12px] text-gray-500'>
+          최적화 모드가 적용한 두 가지: <code>useMemo</code>로 data 배열 참조
+          고정, 각 행을 <code>React.memo</code>로 감쌈.
+        </p>
+      </div>
+
+      <div className='mb-4 h-72 overflow-y-auto rounded-xl border border-gray-200 bg-gray-50 p-2'>
+        <div className='grid grid-cols-1 gap-1'>
+          {data.map((item) => (
+            <RowComp key={item.id} item={item} />
+          ))}
+        </div>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ 기본 — 500번 풀 렌더',
+          code: `function List() {
+  const [tick, setTick] = useState(0)
+
+  // ❌ 매 렌더마다 새 배열 리터럴
+  const data = Array.from({ length: 500 }, makeItem)
+
+  return data.map(item => <Row key={item.id} item={item} />)
+  // Row는 일반 컴포넌트 → 부모 리렌더 시 500개 다 함께 리렌더
+}`,
+          takeaway:
+            '부모가 리렌더될 때마다 500개 행을 전부 다시 계산 → ms 급등',
+        }}
+        after={{
+          label: '✅ useMemo + React.memo',
+          code: `const MemoRow = memo(Row)
+
+function List() {
+  const [tick, setTick] = useState(0)
+
+  // ✅ 참조 안정화
+  const data = useMemo(() => Array.from({ length: 500 }, makeItem), [])
+
+  return data.map(item => <MemoRow key={item.id} item={item} />)
+  // item 참조도 동일 → 500개 전부 리렌더 스킵
+}`,
+          takeaway:
+            '데이터가 변하지 않으면 500개 행이 전부 스킵 → 부모만 미세하게 리렌더',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 대규모 리스트 최적화 순서
+        </div>
+        <ol className='list-decimal space-y-1 pl-5 text-gray-700'>
+          <li>
+            <b>안정적인 key</b> — 인덱스 말고 고유 id. 키가 흔들리면 memo도 무
+            소용.
+          </li>
+          <li>
+            <b>데이터 참조 안정</b> — useMemo로 배열/객체 고정.
+          </li>
+          <li>
+            <b>Row를 React.memo</b> — 행 하나의 리렌더 비용 ↓.
+          </li>
+          <li>
+            <b>Virtualization</b> — 수천 개 이상이면 react-window/TanStack
+            Virtual로 화면에 보이는 것만 렌더.
+          </li>
+        </ol>
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        {label}
+      </div>
+      <div className='mt-0.5 font-mono text-lg font-bold'>{value}</div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/boss-rendering/GoalViz.tsx
+++ b/src/components/playgrounds/boss-rendering/GoalViz.tsx
@@ -1,0 +1,134 @@
+import { ReactNode } from 'react'
+
+export default function BossRenderingGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          실전 디버깅은 &quot;측정 → 가설 → 수정 → 재측정&quot; 루프.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🔬'
+          title='React DevTools Profiler'
+          hook='어떤 컴포넌트가 왜 리렌더됐나'
+        >
+          <p>
+            크롬 확장 <b>React DevTools</b>의 Profiler 탭에서{' '}
+            <code>Record</code>를 누르고 문제 상황을 재현하면 각 컴포넌트의 렌더
+            시간과 이유를 트리로 봐.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>🎯 commit별 플레임 그래프 → 느린 구간 찾기</li>
+            <li>🎯 리렌더 이유 (props 변경 · 부모 리렌더 · hook 변경)</li>
+            <li>🎯 &quot;Why did this render?&quot; 체크박스</li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🚦'
+          title='Lighthouse'
+          hook='프로덕션 체감 점수'
+        >
+          <p>
+            크롬 DevTools의 <b>Lighthouse</b> 탭으로 Performance·Best
+            Practices·SEO·Accessibility 점수를 확인. 모바일·데스크탑 두 시나리오
+            모두 측정 가능.
+          </p>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            💡 70점 미만은 사용자가 체감할 정도. 90점 이상이 권장.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='📊'
+          title='Web Vitals'
+          hook='사용자가 느끼는 3가지 속도 지표'
+        >
+          <p>Google이 정의한 핵심 3지표:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              <b>LCP</b> (Largest Contentful Paint): 가장 큰 콘텐츠 렌더 시간.
+              &lt; 2.5s 권장
+            </li>
+            <li>
+              <b>INP</b> (Interaction to Next Paint, FID 후계): 상호작용 응답
+              속도. &lt; 200ms
+            </li>
+            <li>
+              <b>CLS</b> (Cumulative Layout Shift): 레이아웃이 튀는 정도. &lt;
+              0.1
+            </li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🛠️'
+          title='디버깅 워크플로우'
+          hook='감으로 고치지 말고 측정 루프'
+        >
+          <p>성능 버그는 감이 아니라 데이터로 고쳐.</p>
+          <ol className='mt-2 list-decimal space-y-1 pl-5 text-[13px]'>
+            <li>
+              <b>재현</b> — 느린 순간을 확실히 만들기 (Profiler 녹화)
+            </li>
+            <li>
+              <b>진단</b> — 어떤 컴포넌트/훅이 문제인지
+            </li>
+            <li>
+              <b>가설</b> — memo · useMemo · 리스트 분할 · virtualization?
+            </li>
+            <li>
+              <b>수정</b> — 한 번에 하나씩
+            </li>
+            <li>
+              <b>재측정</b> — 정말 좋아졌는지 숫자로 확인
+            </li>
+          </ol>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 놀이기구의 &quot;미션&quot; 버튼을 이 순서대로 눌러봐.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/boss-rendering/index.tsx
+++ b/src/components/playgrounds/boss-rendering/index.tsx
@@ -1,0 +1,37 @@
+import BossMission from './BossMission'
+import GoalViz from './GoalViz'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function BossRenderingPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#ede9fe] to-[#fce7f3] p-5 ring-1 ring-purple-200'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>👑</span>
+          <div>
+            <div className='font-extrabold text-purple-900'>
+              최종 보스전 — 실전 리스트 최적화
+            </div>
+            <p className='mt-1 text-sm text-purple-900/80'>
+              500개 아이템을 가진 리스트를 기본 모드에서 리렌더시켜 느려지는
+              순간을 체감하고, 최적화 모드로 바꿔 어떻게 달라지는지 ms로 확인.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='📋'
+        title='500개 아이템 리스트 — 기본 vs 최적화'
+        description='useMemo + React.memo 조합으로 수백 개 행의 리렌더를 스킵하는 실전 패턴. 마지막 렌더 ms로 차이 체감.'
+      >
+        <BossMission />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/perf-advanced/ChecklistCards.tsx
+++ b/src/components/playgrounds/perf-advanced/ChecklistCards.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+import CodeBlock from '@/components/stages/CodeBlock'
+
+type Card = {
+  id: string
+  emoji: string
+  title: string
+  metric: string
+  subtitle: string
+  before: { label: string; code: string }
+  after: { label: string; code: string }
+  note: string
+}
+
+const CARDS: Card[] = [
+  {
+    id: 'code-split',
+    emoji: '✂️',
+    title: '코드 스플리팅 (dynamic import)',
+    metric: '초기 JS 번들 감소',
+    subtitle: '모달·차트·에디터 같은 무거운 컴포넌트는 필요할 때만 로드',
+    before: {
+      label: '❌ 전부 초기 번들',
+      code: `import HeavyChart from '@/components/HeavyChart'
+
+export default function Dashboard() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>차트 열기</button>
+      {open && <HeavyChart />}
+    </>
+  )
+}`,
+    },
+    after: {
+      label: '✅ next/dynamic으로 분리',
+      code: `import dynamic from 'next/dynamic'
+
+const HeavyChart = dynamic(() => import('@/components/HeavyChart'), {
+  loading: () => <div>차트 준비 중...</div>,
+  ssr: false,
+})
+
+export default function Dashboard() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>차트 열기</button>
+      {open && <HeavyChart />}
+    </>
+  )
+}`,
+    },
+    note: '처음 페이지 로드에 HeavyChart가 포함되지 않고, 버튼 누를 때 별도 청크로 fetch.',
+  },
+  {
+    id: 'react-lazy',
+    emoji: '🪜',
+    title: 'React.lazy + Suspense',
+    metric: '라우트별 분할',
+    subtitle: '클라이언트 전용 라우트 코드를 페이지 단위로 쪼갬',
+    before: {
+      label: '❌ 라우트 모두 사전 로드',
+      code: `import Settings from './routes/Settings'
+import Billing from './routes/Billing'
+import Invoice from './routes/Invoice'
+
+// 세 라우트 모두 초기 번들에 포함`,
+    },
+    after: {
+      label: '✅ lazy로 필요 시점에 로드',
+      code: `const Settings = lazy(() => import('./routes/Settings'))
+const Billing = lazy(() => import('./routes/Billing'))
+const Invoice = lazy(() => import('./routes/Invoice'))
+
+<Suspense fallback={<Loading />}>
+  <Routes>
+    <Route path='/settings' element={<Settings />} />
+    ...
+  </Routes>
+</Suspense>`,
+    },
+    note: 'Next.js App Router는 파일 기반으로 자동 분할. 별도 설정 없이도 페이지 단위 코드 스플리팅이 기본.',
+  },
+  {
+    id: 'next-image',
+    emoji: '🖼️',
+    title: 'next/image로 자동 최적화',
+    metric: 'LCP 개선 · 대역폭 절약',
+    subtitle: '브라우저 너비에 맞는 해상도·포맷·lazy loading 자동',
+    before: {
+      label: '❌ 원본 그대로',
+      code: `<img
+  src='/hero.jpg'
+  alt='메인 배너'
+  width={1920}
+  height={1080}
+/>
+// 모바일에서도 1920 원본 다운로드, JPEG 그대로`,
+    },
+    after: {
+      label: '✅ next/image',
+      code: `import Image from 'next/image'
+
+<Image
+  src='/hero.jpg'
+  alt='메인 배너'
+  width={1920}
+  height={1080}
+  priority     // LCP 후보면 priority
+  sizes='(max-width: 768px) 100vw, 50vw'
+/>`,
+    },
+    note: 'WebP/AVIF 자동 변환 + srcset 생성 + 화면 밖 이미지는 lazy loading. LCP를 눈에 띄게 개선.',
+  },
+  {
+    id: 'next-font',
+    emoji: '🔤',
+    title: 'next/font로 폰트 최적화',
+    metric: 'CLS 0 + FOUT 방지',
+    subtitle: '빌드 타임 폰트 다운로드, 레이아웃 시프트 없는 로딩',
+    before: {
+      label: '❌ 외부 CDN 링크',
+      code: `<link
+  href='https://fonts.googleapis.com/css2?family=Inter'
+  rel='stylesheet'
+/>
+// 외부 요청 + 폰트 로드 전 기본 폰트로 FOUT`,
+    },
+    after: {
+      label: '✅ next/font (로컬 호스팅)',
+      code: `import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+})
+
+<html className={inter.variable}>...</html>`,
+    },
+    note: '빌드 시 폰트를 자체 호스팅으로 변환 + size-adjust로 레이아웃 시프트 제거.',
+  },
+  {
+    id: 'web-vitals',
+    emoji: '📊',
+    title: 'Web Vitals 목표치',
+    metric: 'LCP < 2.5s · INP < 200ms · CLS < 0.1',
+    subtitle: '사용자 체감 속도의 3대 지표',
+    before: {
+      label: '🟡 평균적인 상태',
+      code: `LCP: 3.2s    (개선 여지)
+INP: 320ms   (느림)
+CLS: 0.18    (레이아웃 튀는 편)`,
+    },
+    after: {
+      label: '🟢 목표치',
+      code: `LCP: 1.8s    ✅ 빠름
+INP: 180ms   ✅ 반응 좋음
+CLS: 0.05    ✅ 안정
+
+// Next.js 기본 + Image/font 최적화 + 코드 스플리팅만 해도
+// 70점대 → 90점대 점프 가능`,
+    },
+    note: '개선 순서: 무거운 JS 줄이기 → LCP 이미지 우선순위 → 인터랙션 핸들러 정리 → 레이아웃 예약.',
+  },
+]
+
+export default function ChecklistCards() {
+  const [activeId, setActiveId] = useState(CARDS[0].id)
+  const [mode, setMode] = useState<'before' | 'after'>('after')
+  const current = CARDS.find((c) => c.id === activeId) ?? CARDS[0]
+  const payload = mode === 'before' ? current.before : current.after
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap gap-2'>
+        {CARDS.map((c) => (
+          <button
+            key={c.id}
+            type='button'
+            onClick={() => setActiveId(c.id)}
+            className={cn(
+              'rounded-full border-2 px-3 py-1.5 text-xs font-bold transition',
+              activeId === c.id
+                ? 'border-[#ff5e48] bg-[#ff5e48] text-white'
+                : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48]'
+            )}
+          >
+            {c.emoji} {c.title.split('(')[0].trim()}
+          </button>
+        ))}
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 ring-1 ring-gray-100'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>{current.emoji}</span>
+          <div>
+            <h4 className='font-extrabold'>{current.title}</h4>
+            <p className='mt-1 text-sm text-gray-600'>{current.subtitle}</p>
+            <span className='mt-2 inline-block rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-bold text-amber-900'>
+              🎯 {current.metric}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className='mb-3 flex gap-2'>
+        <button
+          type='button'
+          onClick={() => setMode('before')}
+          className={cn(
+            'rounded-full px-4 py-1.5 text-xs font-bold transition',
+            mode === 'before'
+              ? 'bg-red-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          🚫 Before
+        </button>
+        <button
+          type='button'
+          onClick={() => setMode('after')}
+          className={cn(
+            'rounded-full px-4 py-1.5 text-xs font-bold transition',
+            mode === 'after'
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          ✅ After
+        </button>
+      </div>
+
+      <CodeBlock
+        filename={payload.label}
+        code={payload.code}
+        lang={current.id === 'web-vitals' ? 'text' : 'tsx'}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 포인트
+        </div>
+        <p className='text-gray-700'>{current.note}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/perf-advanced/GoalViz.tsx
+++ b/src/components/playgrounds/perf-advanced/GoalViz.tsx
@@ -1,0 +1,136 @@
+import { ReactNode } from 'react'
+
+export default function PerfAdvancedGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          리렌더 최적화로 못 잡는 병목은 &quot;번들·이미지·인터랙션&quot;에서
+          잡는다.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='✂️'
+          title='코드 스플리팅'
+          hook='초기 번들은 작게, 나머지는 필요할 때'
+        >
+          <p>
+            사용자가 첫 화면을 보려고 받아야 하는 JS가 작을수록 빨라. 당장 안
+            쓰는 차트·모달·에디터 같은 건 별도 청크로 분리.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>🎯 Next.js App Router — 페이지별 자동 분할</li>
+            <li>
+              🎯 <code>next/dynamic</code> — 특정 컴포넌트만 지연 로드
+            </li>
+            <li>
+              🎯 <code>React.lazy + Suspense</code> — 순수 React 환경
+            </li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🖼️'
+          title='Image · Font 최적화'
+          hook='Next.js 내장 기능만 써도 절반은 해결'
+        >
+          <p>LCP의 주범은 대부분 큰 이미지와 폰트.</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🖼️ <code>next/image</code> — 자동 포맷 변환(WebP/AVIF), 크기별
+              srcset, lazy loading
+            </li>
+            <li>
+              🔤 <code>next/font</code> — 셀프 호스팅 변환, size-adjust로 CLS
+              제거
+            </li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='📦'
+          title='Bundle Analyzer로 크기 분석'
+          hook='측정 안 하면 추측만 한다'
+        >
+          <p>
+            <code>@next/bundle-analyzer</code>로 어느 모듈이 번들에서 큰 자리를
+            차지하는지 시각화. 의외의 라이브러리가 범인인 경우가 많음.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`# 설치
+npm i -D @next/bundle-analyzer
+
+# next.config.ts
+import analyzer from '@next/bundle-analyzer'
+export default analyzer({ enabled: !!process.env.ANALYZE })(config)
+
+# 분석 실행
+ANALYZE=true npm run build`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='📊'
+          title='Web Vitals 개선 (LCP · INP · CLS)'
+          hook='사용자가 느끼는 3가지 속도 감각'
+        >
+          <p>이 세 지표가 Google 검색 순위와 연결돼 있어.</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              <b>LCP</b> — 메인 콘텐츠 뜨는 시간. 이미지 priority로 개선
+            </li>
+            <li>
+              <b>INP</b> — 버튼 눌러서 반응까지 걸리는 시간. 무거운 JS 줄이기
+            </li>
+            <li>
+              <b>CLS</b> — 화면이 튀는 정도. 이미지/폰트에 크기 지정
+            </li>
+          </ul>
+          <p className='mt-3 rounded-lg bg-amber-50 p-2 text-[12px] text-amber-900'>
+            ⚠️ Lighthouse 점수를 70 → 95로 올리는 건 보통 이 3가지의 한두 단계만
+            다듬으면 가능.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/perf-advanced/index.tsx
+++ b/src/components/playgrounds/perf-advanced/index.tsx
@@ -1,0 +1,37 @@
+import ChecklistCards from './ChecklistCards'
+import GoalViz from './GoalViz'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function PerfAdvancedPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🚀</span>
+          <div>
+            <div className='font-extrabold'>
+              리렌더 최적화 다음 단계 — 번들 · 이미지 · Web Vitals
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              앱이 여전히 느리다면 이 단계로 내려와. Next.js 내장 기능 3가지와
+              Web Vitals 목표치를 Before/After로 카드 넘기며 확인.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='📋'
+        title='최적화 체크 카드 5종'
+        description='코드 스플리팅 · React.lazy · next/image · next/font · Web Vitals — 각 카드마다 Before/After 코드와 개선 포인트.'
+      >
+        <ChecklistCards />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/react-compiler/CompilerDemo.tsx
+++ b/src/components/playgrounds/react-compiler/CompilerDemo.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+import CodeBlock from '@/components/stages/CodeBlock'
+
+type Snippet = {
+  id: string
+  emoji: string
+  title: string
+  before: string
+  after: string
+  note: string
+}
+
+const SNIPPETS: Snippet[] = [
+  {
+    id: 'usememo',
+    emoji: '🧮',
+    title: '무거운 계산 — useMemo 없이도 자동 캐시',
+    before: `function UserList({ users }) {
+  // 수동으로 감싸야 했던 계산
+  const sorted = useMemo(
+    () => [...users].sort((a, b) => a.name.localeCompare(b.name)),
+    [users]
+  )
+  return <Table rows={sorted} />
+}`,
+    after: `function UserList({ users }) {
+  // Compiler가 알아서 메모이즈 — 그냥 써라
+  const sorted = [...users].sort((a, b) => a.name.localeCompare(b.name))
+  return <Table rows={sorted} />
+}`,
+    note: 'Compiler는 이 계산이 users에만 의존한다는 걸 분석하고, 내부적으로 메모이즈된 버전으로 변환해.',
+  },
+  {
+    id: 'usecallback',
+    emoji: '🎯',
+    title: '콜백 함수 — useCallback도 자동 처리',
+    before: `function Parent({ onUpdate }) {
+  const handleClick = useCallback(
+    () => onUpdate(Date.now()),
+    [onUpdate]
+  )
+  return <MemoChild onClick={handleClick} />
+}`,
+    after: `function Parent({ onUpdate }) {
+  // 그냥 함수로 쓰면 됨
+  const handleClick = () => onUpdate(Date.now())
+  return <MemoChild onClick={handleClick} />
+}`,
+    note: '함수 참조 안정은 Compiler가 알아서. memo된 자식은 여전히 필요한 때만 리렌더.',
+  },
+  {
+    id: 'object-props',
+    emoji: '📦',
+    title: '인라인 객체 props — 자동 참조 고정',
+    before: `function Card({ user }) {
+  // 매번 새 객체라 자식 memo 무력화
+  const style = { color: user.vip ? 'gold' : 'gray' }
+  return <Avatar style={style} name={user.name} />
+}`,
+    after: `function Card({ user }) {
+  // Compiler가 user.vip에만 반응하도록 메모이즈
+  const style = { color: user.vip ? 'gold' : 'gray' }
+  return <Avatar style={style} name={user.name} />
+}`,
+    note: '코드가 동일. 동작은 달라짐 — 컴파일러 개입 여부만 다르고 작성자는 인지할 필요 없어.',
+  },
+  {
+    id: 'limits',
+    emoji: '🚧',
+    title: '자동화가 놓치는 경우',
+    before: `// ❌ 컴파일러가 분석 못 하는 상황
+function Comp({ fn }) {
+  // fn의 정체를 알 수 없음 (외부 함수)
+  const wrapped = (...args) => fn(...args)
+  return <Child onAction={wrapped} />
+}`,
+    after: `// ✅ 필요하면 여전히 수동으로
+function Comp({ fn }) {
+  const wrapped = useCallback((...args) => fn(...args), [fn])
+  return <Child onAction={wrapped} />
+}`,
+    note: '규칙을 벗어나거나 분석이 어려운 패턴은 Compiler가 포기. 그땐 수동으로 감싸는 게 답. eslint-plugin-react-compiler가 경고로 알려줘.',
+  },
+]
+
+export default function CompilerDemo() {
+  const [active, setActive] = useState<string>(SNIPPETS[0].id)
+  const [mode, setMode] = useState<'before' | 'after'>('after')
+  const current = SNIPPETS.find((s) => s.id === active) ?? SNIPPETS[0]
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap gap-2'>
+        {SNIPPETS.map((s) => (
+          <button
+            key={s.id}
+            type='button'
+            onClick={() => setActive(s.id)}
+            className={cn(
+              'rounded-full border-2 px-3 py-1.5 text-xs font-bold transition',
+              active === s.id
+                ? 'border-[#ff5e48] bg-[#ff5e48] text-white'
+                : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48]'
+            )}
+          >
+            {s.emoji} {s.title.split(' — ')[0]}
+          </button>
+        ))}
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 ring-1 ring-gray-100'>
+        <div className='mb-2 font-extrabold'>
+          {current.emoji} {current.title}
+        </div>
+        <div className='text-sm text-gray-600'>{current.note}</div>
+      </div>
+
+      <div className='mb-3 flex gap-2'>
+        <button
+          type='button'
+          onClick={() => setMode('before')}
+          className={cn(
+            'rounded-full px-4 py-1.5 text-xs font-bold transition',
+            mode === 'before'
+              ? 'bg-red-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          🚫 Compiler 없이 (직접 감싸기)
+        </button>
+        <button
+          type='button'
+          onClick={() => setMode('after')}
+          className={cn(
+            'rounded-full px-4 py-1.5 text-xs font-bold transition',
+            mode === 'after'
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          ✅ Compiler 켬 (자동 메모이즈)
+        </button>
+      </div>
+
+      <CodeBlock
+        filename={
+          mode === 'before' ? 'without-compiler.tsx' : 'with-compiler.tsx'
+        }
+        code={mode === 'before' ? current.before : current.after}
+      />
+
+      <div className='mt-5 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 Compiler는 어떻게 켜나
+        </div>
+        <pre className='mb-2 overflow-x-auto rounded-lg bg-gray-900 p-3 font-mono text-[11px] text-gray-100'>
+          {`// next.config.ts
+experimental: {
+  reactCompiler: true,
+}
+
+// .eslintrc — 컴파일러가 분석 못 하는 코드 경고
+plugins: ['react-compiler']
+rules: { 'react-compiler/react-compiler': 'error' }`}
+        </pre>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 2026년 현재 React 19 기준 <b>opt-in 안정화</b> 단계
+          </li>
+          <li>
+            🎯 최신 코드베이스는 수동 memo 거의 안 써도 됨 (단, legacy 코드는
+            남아있음)
+          </li>
+          <li>
+            🎯 <code>&quot;use memo&quot;</code> 지시어로 특정 함수만 컴파일,{' '}
+            <code>&quot;use no memo&quot;</code>로 제외 가능
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/react-compiler/GoalViz.tsx
+++ b/src/components/playgrounds/react-compiler/GoalViz.tsx
@@ -1,0 +1,133 @@
+import { ReactNode } from 'react'
+
+export default function ReactCompilerGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          Compiler를 이해하면 오히려 memo 3종 세트가 언제 불필요한지가 선명해짐.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🤖'
+          title='Compiler가 자동화하는 것'
+          hook='빌드 시점에 useMemo·useCallback·React.memo 상당 부분을 주입'
+        >
+          <p>React Compiler는 빌드 타임에 코드를 분석해서:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>🎯 비싼 계산을 자동으로 메모이즈</li>
+            <li>🎯 인라인 객체·배열·함수를 참조 안정화</li>
+            <li>🎯 자식 컴포넌트의 불필요한 리렌더 방지</li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            기존에 수동으로 감싸던 90% 이상이 자동화 대상.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🧑‍🔬'
+          title='수동이 여전히 필요한 순간'
+          hook='Compiler가 분석 못 하는 동적 코드'
+        >
+          <p>Compiler는 정적 분석이라 한계가 있어.</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>❌ 외부 함수·라이브러리로 감싼 값 (불투명)</li>
+            <li>❌ 런타임에 결정되는 함수 변형</li>
+            <li>❌ React의 규칙 위반 (hooks of hooks, 조건부 훅 등)</li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 이럴 땐 기존처럼 수동 useMemo/useCallback. 개발자 판단 필요.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🔌'
+          title='eslint-plugin-react-compiler'
+          hook='컴파일러가 포기한 코드에 경고'
+        >
+          <p>
+            <code>eslint-plugin-react-compiler</code>는 Compiler가 메모이즈 못
+            한 파일에 경고를 띄워.
+          </p>
+          <p className='mt-2'>
+            이 경고가 뜨면 &quot;이 부분은 Compiler가 못 도와줄 테니 수동으로
+            최적화할지, 코드 구조를 바꿀지 결정&quot;하는 신호야.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// package.json
+"eslint-plugin-react-compiler": "^19.x"
+
+// eslint.config
+rules: {
+  "react-compiler/react-compiler": "error"
+}`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='📜'
+          title='3종 세트와의 새로운 관계'
+          hook='문법은 그대로, 용도는 좁아짐'
+        >
+          <p>Compiler를 쓰는 프로젝트에서 3종 세트의 역할:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🧙‍♂️ <code>useMemo</code> → 여전히 유용하지만 대부분 생략 가능
+            </li>
+            <li>
+              🎯 <code>useCallback</code> → 특수 경우만 (외부 라이브러리 deps
+              등)
+            </li>
+            <li>
+              🛡️ <code>React.memo</code> → 큰 리스트·차트 같은 자산은 명시적으로
+              유지
+            </li>
+          </ul>
+          <p className='mt-3 rounded-lg bg-amber-50 p-2 text-[12px] text-amber-900'>
+            ⚠️ Compiler를 &quot;안 쓴다&quot;는 전제의 튜토리얼·회사 코드도
+            여전히 많음. 두 방식 모두 읽을 줄 알아야 함.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/react-compiler/index.tsx
+++ b/src/components/playgrounds/react-compiler/index.tsx
@@ -1,0 +1,36 @@
+import CompilerDemo from './CompilerDemo'
+import GoalViz from './GoalViz'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function ReactCompilerPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>useMemo는 과거형이 되어간다</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              React 19부터 안정화된 Compiler가 수동 메모이제이션의 90%를 대체해.
+              시나리오 4개를 Before/After로 훑고, 여전히 수동이 필요한 순간이
+              언제인지 감 잡아보자.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🤖'
+        title='Compiler Before/After 카드 넘기기'
+        description='useMemo · useCallback · 인라인 객체 · 자동화 한계 4가지 시나리오. 버튼 눌러 같은 문제를 두 방식으로 바라보기.'
+      >
+        <CompilerDemo />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/react-memo/GoalViz.tsx
+++ b/src/components/playgrounds/react-memo/GoalViz.tsx
@@ -1,0 +1,128 @@
+import { ReactNode } from 'react'
+
+export default function ReactMemoGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          memo는 &quot;props가 같으면 날 스킵하라&quot;는 약속일 뿐.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🛡️'
+          title='React.memo 동작 원리'
+          hook='얕은 비교(shallow compare)로 props 체크'
+        >
+          <p>
+            <code>memo(Component)</code>로 감싸면 리액트가 <b>매 렌더 직전</b>{' '}
+            props를 이전 props와 비교해. 같으면 리렌더를 건너뛰어.
+          </p>
+          <p className='mt-2'>
+            비교는 <b>얕은 비교</b>. 각 prop에 대해 <code>Object.is</code>로
+            체크. 원시값은 값으로, 객체·배열·함수는 <b>참조로</b>.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='💊'
+          title='언제 효과적인가'
+          hook='큰 컴포넌트 + 참조 안정된 props'
+        >
+          <p>memo가 의미 있는 조건:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🎯 렌더 자체가 <b>비용이 큰</b> 컴포넌트 (DOM 많거나 계산 많음)
+            </li>
+            <li>🎯 부모가 자주 리렌더되는데 이 자식은 가끔만 바뀜</li>
+            <li>
+              🎯 props 참조가 <b>안정</b>되어 있음 (useMemo/useCallback와 함께)
+            </li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🚫'
+          title='언제 쓸모없는가'
+          hook='가벼운 컴포넌트 + 불안정 props = 낭비'
+        >
+          <p>memo 자체도 비교 비용이 있어. 이럴 땐 오히려 손해.</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>❌ 렌더링이 원래 가벼운 컴포넌트 (text, span 등)</li>
+            <li>❌ props로 객체·배열·함수를 참조 고정 없이 넘기는 경우</li>
+            <li>❌ 부모와 함께 거의 항상 같이 바뀌는 자식</li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            👉 측정해보고 효과가 보일 때만.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🎪'
+          title='3종 세트의 조합 효과'
+          hook='memo + useMemo + useCallback 세트로'
+        >
+          <p>이 셋은 하나씩 쓰는 게 아니라 팀플레이야.</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🧙‍♂️ <code>useMemo</code> → 넘기는 값(객체·배열) 참조 고정
+            </li>
+            <li>
+              🎯 <code>useCallback</code> → 넘기는 함수 참조 고정
+            </li>
+            <li>
+              🛡️ <code>React.memo</code> → 자식이 스킵할 권한 획득
+            </li>
+          </ul>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const Child = memo(ChildImpl)
+
+function Parent() {
+  const data = useMemo(() => build(), [])
+  const onAction = useCallback(() => ..., [])
+  return <Child data={data} onAction={onAction} />
+}`}
+          </pre>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/react-memo/MemoShallow.tsx
+++ b/src/components/playgrounds/react-memo/MemoShallow.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { memo, useMemo, useRef, useState } from 'react'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+const MemoNumberBox = memo(function NumberBoxInner({
+  value,
+}: {
+  value: number
+}) {
+  const renders = useRef(0)
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+  return (
+    <Box
+      title='Primitive (number)'
+      value={String(value)}
+      // eslint-disable-next-line react-hooks/refs
+      renders={renders.current}
+      verdict='🟢 같은 값 → 리렌더 스킵'
+    />
+  )
+})
+
+const MemoObjectBox = memo(function ObjectBoxInner({
+  config,
+}: {
+  config: { limit: number }
+}) {
+  const renders = useRef(0)
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+  return (
+    <Box
+      title='Object (매 렌더 새 객체)'
+      value={`{ limit: ${config.limit} }`}
+      // eslint-disable-next-line react-hooks/refs
+      renders={renders.current}
+      verdict='🔴 새 참조 → 매번 리렌더'
+    />
+  )
+})
+
+const MemoStableObjectBox = memo(function StableObjectBoxInner({
+  config,
+}: {
+  config: { limit: number }
+}) {
+  const renders = useRef(0)
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+  return (
+    <Box
+      title='Object (useMemo 고정)'
+      value={`{ limit: ${config.limit} }`}
+      // eslint-disable-next-line react-hooks/refs
+      renders={renders.current}
+      verdict='🟢 같은 참조 → 리렌더 스킵'
+    />
+  )
+})
+
+export default function MemoShallow() {
+  const [bump, setBump] = useState(0)
+
+  const freshConfig = { limit: 10 }
+  const stableConfig = useMemo(() => ({ limit: 10 }), [])
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setBump((b) => b + 1)}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🎲 부모 리렌더 {bump}
+        </button>
+        <span className='text-xs text-gray-500'>
+          누를 때마다 모든 자식의 렌더 조건을 React.memo가 판정
+        </span>
+      </div>
+
+      <div className='mb-4 grid gap-3 sm:grid-cols-3'>
+        <MemoNumberBox value={10} />
+        <MemoObjectBox config={freshConfig} />
+        <MemoStableObjectBox config={stableConfig} />
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 세 자식 모두 <code>React.memo</code>로 감쌌지만
+          props 성격이 달라.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            🟢 <b>Primitive</b>: <code>10 === 10</code>이 true → props 변화 없음
+            → 리렌더 스킵. 카운트가 1에 머무름.
+          </li>
+          <li>
+            🔴 <b>Object (fresh)</b>: 매 렌더마다 부모가{' '}
+            <code>{`{ limit: 10 }`}</code>을 새로 만듦. 얕은 비교가
+            &quot;다르다&quot; 판정 → 계속 리렌더.
+          </li>
+          <li>
+            🟢 <b>Object (useMemo)</b>: 한 번 만들고 같은 참조 유지. memo가
+            &quot;같다&quot; 판정 → 스킵.
+          </li>
+        </ul>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ memo만 감싸고 끝내면',
+          code: `const HeavyList = memo(function HeavyList({ items, filter }) {
+  // 렌더링 비용 큰 컴포넌트
+})
+
+function Parent() {
+  return <HeavyList
+    items={[1,2,3]}              // 매번 새 배열
+    filter={{ mode: 'all' }}     // 매번 새 객체
+  />
+}`,
+          takeaway:
+            'memo가 얕은 비교로 props를 확인하는데 매번 새 참조 → 효과 0',
+        }}
+        after={{
+          label: '✅ useMemo/useCallback과 짝으로',
+          code: `function Parent() {
+  const items = useMemo(() => [1, 2, 3], [])
+  const filter = useMemo(() => ({ mode: 'all' }), [])
+  return <HeavyList items={items} filter={filter} />
+}`,
+          takeaway:
+            '참조 안정화 → memo가 비로소 제대로 작동 → 큰 리스트 성능 ↑',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 얕은 비교(shallow compare) 규칙
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            ✅ 원시값(number, string, boolean): <code>Object.is</code>로 비교 →
+            같은 값이면 스킵
+          </li>
+          <li>
+            ❌ 객체·배열·함수: <b>참조만</b> 비교 → 같은 생김새여도 새 참조면
+            리렌더
+          </li>
+          <li>
+            🎯 그래서 memo는 <code>useMemo</code>·<code>useCallback</code>과
+            거의 세트로 움직여.
+          </li>
+          <li className='pt-2 text-[12px] text-gray-500'>
+            💡 비교 로직을 커스터마이즈하려면{' '}
+            <code>memo(Component, areEqual)</code>로 두 번째 인자에 직접 비교
+            함수를 넣을 수도 있어 (실제로는 거의 안 씀).
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function Box({
+  title,
+  value,
+  renders,
+  verdict,
+}: {
+  title: string
+  value: string
+  renders: number
+  verdict: string
+}) {
+  return (
+    <div className='rounded-xl bg-white p-4 ring-1 ring-gray-200'>
+      <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        {title}
+      </div>
+      <div className='mt-1 font-mono text-xs break-all text-gray-700'>
+        {value}
+      </div>
+      <div className='mt-3 text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        🔁 렌더 횟수
+      </div>
+      <div className='font-mono text-2xl font-extrabold'>{renders}</div>
+      <div className='mt-2 text-[11px] text-gray-600'>{verdict}</div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/react-memo/index.tsx
+++ b/src/components/playgrounds/react-memo/index.tsx
@@ -1,0 +1,37 @@
+import GoalViz from './GoalViz'
+import MemoShallow from './MemoShallow'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function ReactMemoPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              세 자식 모두 memo. 카운트는 왜 달라지나?
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              부모 리렌더 버튼을 연타하고 세 자식의 렌더 횟수를 비교해봐. 얕은
+              비교의 규칙이 한눈에 들어올 거야.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🛡️'
+        title='얕은 비교 시각화 — primitive · 새 객체 · 고정 객체'
+        description='같은 memo 자식이지만 받는 props 성격이 다름. 어떤 경우에 memo가 진짜 스킵하고 어떤 경우 무력해지는지 확인.'
+      >
+        <MemoShallow />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usecallback/CallbackTrap.tsx
+++ b/src/components/playgrounds/usecallback/CallbackTrap.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { memo, useCallback, useRef, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type ChildProps = {
+  onIncrement: () => void
+  label: string
+}
+
+const MemoChild = memo(function ChildInner({ onIncrement, label }: ChildProps) {
+  const renders = useRef(0)
+  // 교육용 렌더 카운터
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+  return (
+    <div className='rounded-xl bg-white p-5 text-center ring-1 ring-gray-200'>
+      <div className='text-3xl'>🧑‍🎤</div>
+      <div className='mt-1 text-sm font-bold'>{label}</div>
+      <div className='mt-2 text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        내가 그려진 횟수
+      </div>
+      {/* eslint-disable-next-line react-hooks/refs */}
+      <div className='font-mono text-2xl font-extrabold'>{renders.current}</div>
+      <button
+        type='button'
+        onClick={onIncrement}
+        className='mt-3 rounded-full bg-gray-900 px-3 py-1 text-xs font-bold text-white hover:bg-gray-700'
+      >
+        ➕ 콜백 호출
+      </button>
+    </div>
+  )
+})
+
+export default function CallbackTrap() {
+  const [count, setCount] = useState(0)
+  const [bump, setBump] = useState(0)
+  const [useCb, setUseCb] = useState(false)
+
+  const stableHandler = useCallback(() => setCount((c) => c + 1), [])
+  const freshHandler = () => setCount((c) => c + 1)
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setBump((b) => b + 1)}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🎲 부모 리렌더 {bump}
+        </button>
+        <button
+          type='button'
+          onClick={() => setUseCb((v) => !v)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            useCb
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          {useCb ? '✅ useCallback 켜짐' : '⬜️ useCallback 꺼짐'}
+        </button>
+        <span className='text-xs text-gray-500'>
+          콜백 호출 누적: <span className='font-mono font-bold'>{count}</span>
+        </span>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 좌우 자식 모두 <code>React.memo</code>로 감싼
+          동일 컴포넌트야. 다른 건 부모가 넘기는 콜백 참조 방식 뿐.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            ❌ <b>Fresh</b>: 매 렌더마다 <code>{'() => ...'}</code>를 새로
+            만들어 넘김 → 자식의 memo 얕은 비교가 &quot;다름&quot; 판정 → 리렌더
+          </li>
+          <li>
+            ✅ <b>Stable</b>: <code>useCallback</code>으로 감싸 참조 고정 →
+            memo가 &quot;같음&quot; 판정 → 자식 리렌더 스킵
+          </li>
+        </ul>
+      </div>
+
+      <div className='mb-4 grid grid-cols-2 gap-3'>
+        <MemoChild label='❌ Fresh 콜백' onIncrement={freshHandler} />
+        <MemoChild label='✅ Stable 콜백' onIncrement={stableHandler} />
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ useCallback 없이',
+          code: `const Child = memo(function Child({ onClick }) {
+  return <button onClick={onClick}>...</button>
+})
+
+function Parent() {
+  const [n, setN] = useState(0)
+  // 매 렌더마다 새로 생성되는 함수
+  const handleClick = () => console.log('click')
+  return <Child onClick={handleClick} />
+}`,
+          takeaway:
+            'memo로 감싼 의미가 사라짐. props 참조가 매번 달라서 자식이 계속 리렌더',
+        }}
+        after={{
+          label: '✅ useCallback으로 참조 안정',
+          code: `function Parent() {
+  const [n, setN] = useState(0)
+  const handleClick = useCallback(
+    () => console.log('click'),
+    []  // deps 비어있으면 마운트 이후 같은 참조 유지
+  )
+  return <Child onClick={handleClick} />
+}`,
+          takeaway:
+            'deps가 그대로면 같은 함수 참조를 돌려줌 → 자식 memo가 제대로 작동',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 왜 · 언제
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 <b>왜</b>: 자바스크립트에서 함수 리터럴은 매번 새로 만들어지는
+            객체야. <code>React.memo</code>·<code>useEffect</code>·커스텀 훅
+            deps처럼 &quot;참조&quot;를 보는 자리에 그대로 넘기면 매번
+            &quot;다른 것&quot;으로 보여.
+          </li>
+          <li>
+            🕰️ <b>언제</b>: 자식이 <code>React.memo</code>된 경우, 다른 훅의
+            deps에 들어가는 경우, 커스텀 훅 내부에서 돌려주는 함수 등.
+          </li>
+          <li>
+            ⚠️ <b>주의</b>: 그냥 이벤트 핸들러(버튼 onClick처럼 일반 DOM에 쓰는
+            함수)엔 쓸 필요 없어. 그때는 그냥 인라인 함수가 더 읽기 좋음.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usecallback/GoalViz.tsx
+++ b/src/components/playgrounds/usecallback/GoalViz.tsx
@@ -1,0 +1,125 @@
+import { ReactNode } from 'react'
+
+export default function UseCallbackGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          useCallback은 &quot;useMemo의 함수판&quot;이야. 쌍으로 이해하면 빠름.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🪞'
+          title='useCallback = useMemo의 함수판'
+          hook='"같은 함수를 또 돌려줘" 약속'
+        >
+          <p>
+            <code>useCallback(fn, deps)</code>는{' '}
+            <code>useMemo(() =&gt; fn, deps)</code>와 똑같아. 다만 함수가
+            값이라서 문법적으로 편한 전용 버전이야.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// 둘은 같은 의미
+const fn = useCallback(() => doIt(x), [x])
+const fn = useMemo(() => () => doIt(x), [x])`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🔗'
+          title='함수 참조 동일성이 왜 중요한가'
+          hook='넘겨받는 쪽이 참조로 비교하면 매번 다르다'
+        >
+          <p>
+            JS에서 <code>{`(() => {}) === (() => {})`}</code> 은 항상{' '}
+            <b>false</b>. 리액트는 props와 deps를 참조로 비교해. 그래서
+            &quot;같은 일을 하는 함수&quot; 여도 매번 다르게 판정돼.
+          </p>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            👉 놀이기구에서 Fresh 자식 vs Stable 자식 카운트 차이로 확인.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🛡️'
+          title='React.memo와의 시너지'
+          hook='memo 혼자로는 반쪽, useCallback이 짝'
+        >
+          <p>
+            <code>React.memo</code>로 자식을 감싸도 부모가 새 함수를 props로
+            내려주면 의미 없음. <b>둘이 같이 있어야</b> 리렌더 스킵이 작동.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const Child = memo(ChildImpl)
+
+function Parent() {
+  const onClick = useCallback(fn, [])  // ← 이 짝이 있어야 memo 효과
+  return <Child onClick={onClick} />
+}`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🧩'
+          title='커스텀 훅에서 왜 쓰는가'
+          hook='훅이 돌려주는 함수도 참조가 흔들리면 안 됨'
+        >
+          <p>
+            커스텀 훅이 <code>return fn</code>을 해주는데 그 함수를 다른 훅
+            deps로 받아쓴다면, useCallback으로 감싸야 의도대로 동작해.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`function useToggle(initial: boolean) {
+  const [v, setV] = useState(initial)
+  const toggle = useCallback(() => setV(x => !x), [])
+  return [v, toggle] as const
+}`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            호출자가 <code>toggle</code>을 useEffect deps에 넣어도 무한 루프 안
+            생김.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/usecallback/index.tsx
+++ b/src/components/playgrounds/usecallback/index.tsx
@@ -1,0 +1,38 @@
+import CallbackTrap from './CallbackTrap'
+import GoalViz from './GoalViz'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseCallbackPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              memo 자식에 콜백 넘길 때 같이 온다
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              좌우 자식 모두 memo야. 어느 쪽이 리렌더를 먹고 어느 쪽이
+              스킵하는지, 🎲 부모 리렌더 버튼을 연타하며 카운트 차이를 직접
+              느껴봐.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🪞'
+        title='Fresh vs Stable 콜백 참조 비교'
+        description='같은 memo 자식 2개. 한 쪽엔 매 렌더마다 새 함수, 한 쪽엔 useCallback으로 고정. 카운트가 갈라지는 걸 눈으로 확인.'
+      >
+        <CallbackTrap />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/quest/Achievement.tsx
+++ b/src/components/quest/Achievement.tsx
@@ -1,23 +1,36 @@
+'use client'
+
 import { cn } from '@/lib/cn'
-import type { Achievement as AchievementType } from '@/data/achievements'
+import { achievements } from '@/data/achievements'
+import { useProgress } from '@/lib/progress'
 
-type AchievementProps = {
-  achievement: AchievementType
-}
-
-export default function Achievement({ achievement }: AchievementProps) {
+export default function AchievementGrid() {
+  const progress = useProgress()
   return (
-    <div
-      className={cn(
-        'rounded-2xl border-2 p-5 text-center transition-all duration-300',
-        achievement.unlocked
-          ? 'border-[#f59e0b] bg-[#fef3c7]'
-          : 'border-gray-100 bg-white opacity-40 grayscale'
-      )}
-    >
-      <div className='mb-2 text-4xl'>{achievement.emoji}</div>
-      <div className='mb-1 text-[13px] font-bold'>{achievement.title}</div>
-      <div className='text-[11px] text-gray-500'>{achievement.description}</div>
+    <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-6'>
+      {achievements.map((a) => {
+        const unlocked = a.isUnlocked(progress)
+        return (
+          <div
+            key={a.id}
+            className={cn(
+              'relative rounded-2xl border-2 p-5 text-center transition-all duration-300',
+              unlocked
+                ? 'border-[#f59e0b] bg-[#fef3c7]'
+                : 'border-gray-100 bg-white opacity-40 grayscale'
+            )}
+          >
+            {unlocked && (
+              <span className='absolute -top-2 -right-2 rounded-full bg-amber-500 px-2 py-0.5 text-[10px] font-bold text-white shadow'>
+                NEW
+              </span>
+            )}
+            <div className='mb-2 text-4xl'>{a.emoji}</div>
+            <div className='mb-1 text-[13px] font-bold'>{a.title}</div>
+            <div className='text-[11px] text-gray-500'>{a.description}</div>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/quest/Dashboard.tsx
+++ b/src/components/quest/Dashboard.tsx
@@ -1,22 +1,21 @@
 'use client'
 
 import { totalExamples, totalStages } from '@/data/stages'
-import { achievements } from '@/data/achievements'
+import { achievements, unlockedAchievementCount } from '@/data/achievements'
 import { completedCount, useProgress } from '@/lib/progress'
 
 type DashboardProps = {
   postsDone?: number
   postsTotal?: number
-  badgesDone?: number
 }
 
 export default function Dashboard({
   postsDone = 0,
   postsTotal = 11,
-  badgesDone = 0,
 }: DashboardProps) {
   const progress = useProgress()
   const stagesDone = completedCount(progress)
+  const badgesDone = unlockedAchievementCount(progress)
   const percent =
     totalStages === 0 ? 0 : Math.round((stagesDone / totalStages) * 100)
   const badgesTotal = achievements.length

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -18,14 +18,17 @@ type StageCardProps = {
 export default function StageCard({ stage }: StageCardProps) {
   const progress = useProgress()
   const done = isCompleted(stage.id, progress)
-  const effectiveStatus = done ? 'completed' : stage.status
+  const playgroundReady = hasPlayground(stage.id)
+  // 놀이기구가 등록된 스테이지는 자동으로 '진행 가능' 처리
+  const baseStatus =
+    stage.status === 'locked' && playgroundReady ? 'active' : stage.status
+  const effectiveStatus = done ? 'completed' : baseStatus
   const statusIcon =
     effectiveStatus === 'completed'
       ? '✅'
       : effectiveStatus === 'active'
         ? '🔓'
         : '🔒'
-  const playgroundReady = hasPlayground(stage.id)
 
   return (
     <Link

--- a/src/components/stages/StageDetail.tsx
+++ b/src/components/stages/StageDetail.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { categoryMeta, type Stage } from '@/data/stages'
-import { playgrounds } from '@/data/playgrounds'
+import { hasPlayground, playgrounds } from '@/data/playgrounds'
 import {
   difficultyBadge,
   difficultyLabel,
@@ -50,7 +50,7 @@ export default function StageDetail({ stage }: Props) {
             </span>
           )}
           <span className='text-xs text-gray-500'>⏱ {stage.hours}시간</span>
-          {stage.status === 'locked' && (
+          {stage.status === 'locked' && !hasPlayground(stage.id) && (
             <span className='ml-2 text-xs font-bold text-gray-500'>
               🔒 잠김 — 미리보기
             </span>

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -1,52 +1,73 @@
-export type Achievement = {
+import { allStages, type Stage } from './stages'
+import type { Progress } from '@/lib/progress'
+
+export type AchievementRule = {
   id: string
   emoji: string
   title: string
   description: string
-  unlocked: boolean
+  isUnlocked: (progress: Progress) => boolean
 }
 
-export const achievements: Achievement[] = [
+const done = (progress: Progress, id: string): boolean =>
+  progress.completedAt[id] != null
+
+const categoryComplete = (
+  progress: Progress,
+  category: Stage['category']
+): boolean =>
+  allStages
+    .filter((s) => s.category === category)
+    .every((s) => done(progress, s.id))
+
+export const achievements: AchievementRule[] = [
   {
     id: 'first-render',
     emoji: '🎬',
     title: 'First Render',
-    description: 'STAGE 1 클리어',
-    unlocked: false,
+    description: '렌더링 기초 정복',
+    isUnlocked: (p) => done(p, 'stage-1-rendering'),
   },
   {
     id: 'memo-master',
     emoji: '🧙‍♂️',
     title: '메모리 마스터',
     description: 'useMemo 정복',
-    unlocked: false,
+    isUnlocked: (p) => done(p, 'stage-2-usememo'),
   },
   {
     id: 'shield-knight',
     emoji: '🛡️',
     title: '방패의 기사',
-    description: '3종 세트 완성',
-    unlocked: false,
+    description: '메모이제이션 3종 완성',
+    isUnlocked: (p) =>
+      done(p, 'stage-2-usememo') &&
+      done(p, 'stage-3-usecallback') &&
+      done(p, 'stage-4-react-memo'),
   },
   {
     id: 'hook-artisan',
     emoji: '🔨',
     title: '훅 장인',
-    description: '커스텀 훅 6개',
-    unlocked: false,
+    description: '🎣 훅 탭 전부 클리어',
+    isUnlocked: (p) => categoryComplete(p, 'hooks'),
   },
   {
     id: 'debugger',
     emoji: '🐛',
     title: '디버거',
     description: '보스전 클리어',
-    unlocked: false,
+    isUnlocked: (p) => done(p, 'boss-rendering'),
   },
   {
     id: 'react-wizard',
     emoji: '👑',
     title: 'React Wizard',
     description: '전 스테이지 완주',
-    unlocked: false,
+    isUnlocked: (p) => allStages.every((s) => done(p, s.id)),
   },
 ]
+
+export function unlockedAchievementCount(progress: Progress): number {
+  return achievements.filter((a) => a.isUnlocked(progress)).length
+}

--- a/src/data/playgrounds.ts
+++ b/src/data/playgrounds.ts
@@ -1,5 +1,10 @@
 import type { ComponentType } from 'react'
 import UseMemoPlayground from '@/components/playgrounds/usememo'
+import UseCallbackPlayground from '@/components/playgrounds/usecallback'
+import ReactMemoPlayground from '@/components/playgrounds/react-memo'
+import ReactCompilerPlayground from '@/components/playgrounds/react-compiler'
+import BossRenderingPlayground from '@/components/playgrounds/boss-rendering'
+import PerfAdvancedPlayground from '@/components/playgrounds/perf-advanced'
 import RenderingPlayground from '@/components/playgrounds/rendering'
 import UseStatePlayground from '@/components/playgrounds/usestate'
 import UseEffectPlayground from '@/components/playgrounds/useeffect'
@@ -8,13 +13,20 @@ import UseRefPlayground from '@/components/playgrounds/useref'
 import ErrorBoundaryPlayground from '@/components/playgrounds/error-boundary'
 
 export const playgrounds: Record<string, ComponentType> = {
+  // 🎣 훅
   'stage-1-rendering': RenderingPlayground,
-  'stage-2-usememo': UseMemoPlayground,
   'stage-5-usestate': UseStatePlayground,
   'stage-6-useeffect': UseEffectPlayground,
   'stage-7-custom-hooks': CustomHooksPlayground,
   'stage-8-useref': UseRefPlayground,
   'stage-error-boundary': ErrorBoundaryPlayground,
+  // ⚡ 성능
+  'stage-2-usememo': UseMemoPlayground,
+  'stage-3-usecallback': UseCallbackPlayground,
+  'stage-4-react-memo': ReactMemoPlayground,
+  'stage-react-compiler': ReactCompilerPlayground,
+  'boss-rendering': BossRenderingPlayground,
+  'stage-perf-advanced': PerfAdvancedPlayground,
 }
 
 export const hasPlayground = (stageId: string): boolean =>


### PR DESCRIPTION
closes #19

⚡ 성능 탭 5스테이지 + 사용자 지적 2건(잠김 표시 / 뱃지) 한 번에 해결.

## 새 놀이기구 5종

- **useCallback** (`/stages/stage-3-usecallback`) — CallbackTrap (memo 자식 좌우 비교)
- **React.memo** (`/stages/stage-4-react-memo`) — MemoShallow (primitive · 새 객체 · useMemo 객체 3종 얕은 비교)
- **React Compiler** (`/stages/stage-react-compiler`) — CompilerDemo (4 시나리오 Before/After)
- **BOSS 렌더링** (`/stages/boss-rendering`) — BossMission (500 리스트 기본/최적화 모드 + 렌더 ms)
- **성능 최적화 심화** (`/stages/stage-perf-advanced`) — ChecklistCards (코드 스플리팅 · React.lazy · next/image · next/font · Web Vitals 5장)

## 버그 · UX 수정

**🔓 Active 자동화**
- StageCard: `hasPlayground(stageId)` 이면 `status: 'locked'` 를 `'active'` 로 자동 승격
- StageDetail: 놀이기구 있으면 "잠김 — 미리보기" 배지 숨김
- 이제 새 배치 올릴 때마다 데이터 수정 불필요

**🏆 뱃지 자동 해금**
- `achievements` 데이터: `unlocked` 필드 → `isUnlocked(progress)` 함수 기반으로 재설계
- 규칙:
  - First Render → 렌더링 기초 클리어
  - 메모리 마스터 → useMemo 클리어
  - 방패의 기사 → useMemo + useCallback + React.memo 3종 완성
  - 훅 장인 → 🎣 훅 탭 전체 (6개) 완주
  - 디버거 → 보스전 클리어
  - React Wizard → 전 스테이지 완주
- Achievement → AchievementGrid (client)로 전환, `useProgress`로 실시간 해금
- Dashboard 뱃지 카운트도 자동 반영

## 전체 현황

- 🎣 훅: 6/6 ✅
- ⚡ 성능 ⭐: 6/6 ✅
- 🗂 상태: 0/4
- 🌊 API: 0/6
- 🛠 인프라: 0/6
- **플레이 가능 스테이지 12/28**

## 다음 배치

Batch 4 — 🗂 상태 관리 4개 (useContext · useReducer · TanStack Query · Zustand/Jotai/RTK)
