### PR TITLE
✨ Feature: 상태 관리 탭 4개 놀이기구

### DIFF
--- a/src/components/playgrounds/state-libs/CounterComparison.tsx
+++ b/src/components/playgrounds/state-libs/CounterComparison.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+import CodeBlock from '@/components/stages/CodeBlock'
+
+type Lib = 'zustand' | 'jotai' | 'rtk'
+
+type LibInfo = {
+  id: Lib
+  emoji: string
+  title: string
+  subtitle: string
+  tagline: string
+  setup: string
+  code: string
+  pros: string[]
+  cons: string[]
+}
+
+const LIBS: Record<Lib, LibInfo> = {
+  zustand: {
+    id: 'zustand',
+    emoji: '🐻',
+    title: 'Zustand',
+    subtitle: '제일 가볍고 직관적. 2026년 기준 가장 인기',
+    tagline: 'Hook 같은 선언 + 외부 store',
+    setup: `npm i zustand`,
+    code: `// store.ts
+import { create } from 'zustand'
+
+type State = {
+  count: number
+  inc: () => void
+  dec: () => void
+  reset: () => void
+}
+
+export const useCounter = create<State>((set) => ({
+  count: 0,
+  inc: () => set((s) => ({ count: s.count + 1 })),
+  dec: () => set((s) => ({ count: s.count - 1 })),
+  reset: () => set({ count: 0 }),
+}))
+
+// 사용 — 컴포넌트에서
+function Counter() {
+  // 구독할 값·함수만 셀렉트 (해당 값 바뀔 때만 리렌더)
+  const count = useCounter((s) => s.count)
+  const inc = useCounter((s) => s.inc)
+
+  return <button onClick={inc}>{count}</button>
+}`,
+    pros: [
+      '✅ 학습 곡선 낮음, API 딱 useState 확장판 느낌',
+      '✅ 셀렉터로 부분 구독 → 자동 리렌더 최소화',
+      '✅ Provider 래핑 불필요 (전역 훅)',
+      '✅ 미들웨어 · persist · devtools 지원',
+    ],
+    cons: [
+      '⚠️ 공식 devtools는 Redux보다 간소',
+      '⚠️ 매우 큰 팀에선 액션 타입 강제가 약해 문서화 필요',
+    ],
+  },
+  jotai: {
+    id: 'jotai',
+    emoji: '⚛️',
+    title: 'Jotai',
+    subtitle: 'atomic 모델. 작은 값 여러 개를 독립적으로 구독',
+    tagline: '"원자" 단위의 state',
+    setup: `npm i jotai`,
+    code: `// atoms.ts
+import { atom } from 'jotai'
+
+export const countAtom = atom(0)
+// 파생 atom — read-only
+export const doubledAtom = atom((get) => get(countAtom) * 2)
+// 쓰기 가능 atom
+export const incAtom = atom(null, (get, set) =>
+  set(countAtom, get(countAtom) + 1)
+)
+
+// 사용
+import { useAtom, useSetAtom } from 'jotai'
+
+function Counter() {
+  const [count] = useAtom(countAtom)
+  const inc = useSetAtom(incAtom)
+
+  return <button onClick={inc}>{count}</button>
+}
+
+function Doubled() {
+  // 파생 atom만 구독 — countAtom이 바뀔 때만 반응
+  const [doubled] = useAtom(doubledAtom)
+  return <div>2x = {doubled}</div>
+}`,
+    pros: [
+      '✅ atom이 단위 — 세밀한 구독이 자연스러움',
+      '✅ 파생 atom (computed) 작성이 직관적',
+      '✅ Suspense · React 19 Actions와 잘 맞음',
+      '✅ React만의 관점에 맞춰 설계됨',
+    ],
+    cons: [
+      '⚠️ atom이 많아지면 구조 관리가 필요 (폴더·파일 조직)',
+      '⚠️ Redux만큼 devtools가 성숙하진 않음',
+    ],
+  },
+  rtk: {
+    id: 'rtk',
+    emoji: '🧱',
+    title: 'Redux Toolkit',
+    subtitle: '전통의 강자. 큰 팀 · 복잡한 앱에서 여전히 유효',
+    tagline: 'reducer 기반 공식 스택',
+    setup: `npm i @reduxjs/toolkit react-redux`,
+    code: `// counterSlice.ts
+import { createSlice } from '@reduxjs/toolkit'
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  initialState: { count: 0 },
+  reducers: {
+    inc: (s) => { s.count += 1 },     // Immer로 mutation처럼 작성
+    dec: (s) => { s.count -= 1 },
+    reset: (s) => { s.count = 0 },
+  },
+})
+
+export const { inc, dec, reset } = counterSlice.actions
+
+// store.ts
+import { configureStore } from '@reduxjs/toolkit'
+export const store = configureStore({
+  reducer: { counter: counterSlice.reducer },
+})
+
+// 사용
+import { Provider, useSelector, useDispatch } from 'react-redux'
+
+function Counter() {
+  const count = useSelector((s: RootState) => s.counter.count)
+  const dispatch = useDispatch()
+  return <button onClick={() => dispatch(inc())}>{count}</button>
+}
+
+// App.tsx
+<Provider store={store}><App /></Provider>`,
+    pros: [
+      '✅ 가장 성숙한 devtools + 타임트래블',
+      '✅ RTK Query 내장 (서버 상태 + 클라 상태 모두)',
+      '✅ 미들웨어 생태계 풍부',
+      '✅ 대규모 팀의 규칙 강제에 유리',
+    ],
+    cons: [
+      '⚠️ Provider 래핑 · selector · action 등 보일러플레이트가 여전히 존재',
+      '⚠️ 간단한 앱엔 과함',
+    ],
+  },
+}
+
+export default function CounterComparison() {
+  const [active, setActive] = useState<Lib>('zustand')
+  const info = LIBS[active]
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap gap-2'>
+        {(Object.keys(LIBS) as Lib[]).map((id) => {
+          const l = LIBS[id]
+          return (
+            <button
+              key={id}
+              type='button'
+              onClick={() => setActive(id)}
+              className={cn(
+                'rounded-full border-2 px-4 py-2 text-sm font-bold transition',
+                active === id
+                  ? 'border-[#ff5e48] bg-[#ff5e48] text-white'
+                  : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48]'
+              )}
+            >
+              {l.emoji} {l.title}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className='mb-3 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <div className='flex items-start gap-3'>
+          <span className='text-4xl'>{info.emoji}</span>
+          <div>
+            <h4 className='font-extrabold'>{info.title}</h4>
+            <p className='text-sm text-gray-600'>{info.subtitle}</p>
+            <span className='mt-2 inline-block rounded-full bg-gray-900 px-2 py-0.5 text-[11px] font-bold text-white'>
+              {info.tagline}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className='mb-3'>
+        <div className='mb-1 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          📦 설치
+        </div>
+        <pre className='rounded-lg bg-gray-900 p-3 font-mono text-[11px] text-gray-100'>
+          {info.setup}
+        </pre>
+      </div>
+
+      <CodeBlock
+        filename={`${info.title.toLowerCase()}-counter.tsx`}
+        code={info.code}
+      />
+
+      <div className='mt-4 grid gap-3 md:grid-cols-2'>
+        <div className='rounded-xl bg-emerald-50 p-4 ring-1 ring-emerald-200'>
+          <div className='text-xs font-bold tracking-wider text-emerald-800 uppercase'>
+            👍 장점
+          </div>
+          <ul className='mt-2 space-y-1 text-sm text-emerald-900'>
+            {info.pros.map((p) => (
+              <li key={p}>{p}</li>
+            ))}
+          </ul>
+        </div>
+        <div className='rounded-xl bg-amber-50 p-4 ring-1 ring-amber-200'>
+          <div className='text-xs font-bold tracking-wider text-amber-800 uppercase'>
+            ⚠️ 고민할 점
+          </div>
+          <ul className='mt-2 space-y-1 text-sm text-amber-900'>
+            {info.cons.map((c) => (
+              <li key={c}>{c}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 어떤 걸 고를까
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 작은~중간 앱, 팀이 가볍고 빠르게 가고 싶다 → <b>Zustand</b> (요즘
+            기본값)
+          </li>
+          <li>
+            🎯 값 단위로 세밀한 구독이 필요하거나, Suspense·Actions 연계 →{' '}
+            <b>Jotai</b>
+          </li>
+          <li>
+            🎯 큰 팀 + 복잡한 도메인 + devtools·미들웨어 풍성함 필수 →{' '}
+            <b>Redux Toolkit</b>
+          </li>
+          <li className='pt-2 text-[12px] text-gray-500'>
+            💡 서버 상태는 어느 걸 써도 TanStack Query 또는 RTK Query로 분리.
+            &quot;클라 상태 라이브러리&quot;에 서버 상태까지 우겨넣지 마.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/state-libs/GoalViz.tsx
+++ b/src/components/playgrounds/state-libs/GoalViz.tsx
@@ -1,0 +1,143 @@
+import { ReactNode } from 'react'
+
+export default function StateLibsGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          &quot;어떤 게 최고&quot;가 아니라 &quot;어떤 상황에 뭐가
+          어울리나&quot;.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🐻'
+          title='Zustand (가장 쉬움, 추천)'
+          hook='Hook 기반 전역 store. Provider 없음'
+        >
+          <p>
+            <code>create()</code> 한 줄로 store를 만들고, 컴포넌트는 훅처럼
+            구독. 셀렉터로 부분만 골라 받으면 필요한 값 바뀔 때만 리렌더.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const count = useCounter(s => s.count)    // count만 구독
+const inc = useCounter(s => s.inc)        // inc 함수만 구독`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='⚛️'
+          title='Jotai (atomic 패턴)'
+          hook='작은 값 여러 개 = 여러 atom'
+        >
+          <p>
+            state를 하나의 큰 store가 아니라 <b>여러 원자</b>로 나눠서 관리. 각
+            원자를 독립적으로 구독·파생시킬 수 있어.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const count = atom(0)
+const doubled = atom(get => get(count) * 2)  // 파생
+
+const [c] = useAtom(count)
+const [d] = useAtom(doubled)  // c 바뀔 때만 여기도 바뀜`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🧱'
+          title='Redux Toolkit (전통, 여전히 쓰임)'
+          hook='큰 팀의 규칙 강제 · 성숙한 devtools'
+        >
+          <p>
+            &quot;액션 · 리듀서 · selector · 미들웨어&quot;의 정통파. RTK가
+            Redux의 보일러플레이트를 줄이면서도 철학은 유지.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>🎯 시간 여행 디버깅, action log가 필요할 때 최고</li>
+            <li>🎯 RTK Query로 서버 상태도 한 스택에 통합 가능</li>
+            <li>🎯 대규모 앱의 관례·패턴이 잘 문서화돼 있음</li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🎯'
+          title='언제 뭘 쓸지 결정 기준'
+          hook='성능·보일러플레이트·DX 삼각 균형'
+        >
+          <table className='w-full text-[12px]'>
+            <thead>
+              <tr className='border-b border-gray-200 text-left text-gray-500'>
+                <th className='py-1 pr-2'></th>
+                <th className='py-1 pr-2'>Zustand</th>
+                <th className='py-1 pr-2'>Jotai</th>
+                <th className='py-1'>RTK</th>
+              </tr>
+            </thead>
+            <tbody className='text-gray-700'>
+              <tr className='border-b border-gray-100'>
+                <td className='py-1 pr-2 font-semibold'>보일러</td>
+                <td className='py-1 pr-2'>🟢 적음</td>
+                <td className='py-1 pr-2'>🟢 적음</td>
+                <td className='py-1'>🟡 중간</td>
+              </tr>
+              <tr className='border-b border-gray-100'>
+                <td className='py-1 pr-2 font-semibold'>세밀 구독</td>
+                <td className='py-1 pr-2'>🟢 셀렉터</td>
+                <td className='py-1 pr-2'>🟢 atom</td>
+                <td className='py-1'>🟢 selector</td>
+              </tr>
+              <tr>
+                <td className='py-1 pr-2 font-semibold'>devtools</td>
+                <td className='py-1 pr-2'>🟡 기본</td>
+                <td className='py-1 pr-2'>🟡 기본</td>
+                <td className='py-1'>🟢 최상</td>
+              </tr>
+            </tbody>
+          </table>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            💡 결정을 뒤집기 어려우니 팀 · 회사가 이미 쓰는 게 있으면 그대로
+            따라가는 게 현실적.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/state-libs/index.tsx
+++ b/src/components/playgrounds/state-libs/index.tsx
@@ -1,0 +1,38 @@
+import CounterComparison from './CounterComparison'
+import GoalViz from './GoalViz'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function StateLibsPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              같은 Todo/카운터를 3가지 방식으로
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              라이브러리는 취향이자 팀의 선택이야. 탭을 눌러가며 같은 카운터가
+              어떤 문법으로 쓰이는지 비교해봐. 실제로 설치는 안 했고 코드만
+              보여줘.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🏛️'
+        title='카운터 3가지 방식 코드 비교'
+        description='Zustand · Jotai · Redux Toolkit의 설치·코드·장단점. 프로젝트 결정할 때 참고용 카드.'
+      >
+        <CounterComparison />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/tanstack-query/GoalViz.tsx
+++ b/src/components/playgrounds/tanstack-query/GoalViz.tsx
@@ -1,0 +1,152 @@
+import { ReactNode } from 'react'
+
+export default function TanstackQueryGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          서버 상태는 &quot;내가 관리하는 값&quot;이 아니라 &quot;저쪽이
+          원본&quot;이야.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🗄️'
+          title='서버 상태 vs 클라이언트 상태'
+          hook='성격이 다르니 도구도 다르다'
+        >
+          <p>클라이언트 상태 (useState/useReducer가 해결):</p>
+          <ul className='mt-1 space-y-0.5 text-[13px]'>
+            <li>📦 모달 열림/닫힘, 폼 입력값, 탭 선택</li>
+            <li>📦 전적으로 이 앱이 주인</li>
+          </ul>
+          <p className='mt-2'>서버 상태 (TanStack Query 영역):</p>
+          <ul className='mt-1 space-y-0.5 text-[13px]'>
+            <li>🌐 원본은 서버, 내 손이 떠나면 낡음</li>
+            <li>🌐 비동기·실패·재시도·타이밍이 기본 옵션</li>
+            <li>🌐 여러 곳에서 같은 데이터가 필요</li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='⏱️'
+          title='캐시 · stale · refetch 전략'
+          hook='"아직 신선한가? 다시 물어볼까?" 의 규칙'
+        >
+          <ul className='space-y-1 text-[13px]'>
+            <li>
+              <b>staleTime</b> — 이 시간 안에는 &quot;아직 신선&quot; 간주.
+              refetch 안 함
+            </li>
+            <li>
+              <b>gcTime</b> — 구독자가 없어진 뒤 캐시를 얼마나 유지할지
+            </li>
+            <li>
+              <b>refetchOnWindowFocus</b> — 탭 돌아올 때 갱신
+            </li>
+            <li>
+              <b>refetchInterval</b> — 정기 폴링
+            </li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            💡 대부분 staleTime만 조정하면 충분. 기본값으로도 합리적.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🪄'
+          title='Optimistic Update 패턴'
+          hook='서버 응답 기다리지 말고 UI 먼저 바꾸기'
+        >
+          <p>
+            좋아요 버튼 같은 건 응답을 기다리면 굼뜨게 느껴져. Optimistic
+            update는 UI를 즉시 업데이트하고 서버 응답은 배경에서 처리.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`useMutation({
+  mutationFn: likePost,
+  onMutate: async (postId) => {
+    await qc.cancelQueries({ queryKey: ['posts'] })
+    const prev = qc.getQueryData(['posts'])
+    qc.setQueryData(['posts'], (old) => bumpLike(old, postId))
+    return { prev }
+  },
+  onError: (_err, _postId, ctx) => {
+    qc.setQueryData(['posts'], ctx?.prev)  // 롤백
+  },
+  onSettled: () => {
+    qc.invalidateQueries({ queryKey: ['posts'] })
+  },
+})`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='♾️'
+          title='infinite query · pagination'
+          hook='페이지·무한 스크롤의 표준 패턴'
+        >
+          <p>
+            페이지별로 나눠 불러와 합치는 건 자주 나와.{' '}
+            <code>useInfiniteQuery</code>가 데이터 이어붙이기·다음 페이지 조건을
+            관리해줘.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const {
+  data,           // { pages: [...], pageParams: [...] }
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+} = useInfiniteQuery({
+  queryKey: ['posts'],
+  queryFn: ({ pageParam = 0 }) => fetchPage(pageParam),
+  getNextPageParam: (last) => last.nextCursor,
+  initialPageParam: 0,
+})`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            무한 스크롤 컴포넌트는 IntersectionObserver로 바닥을 감지해 호출.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/tanstack-query/QueryCache.tsx
+++ b/src/components/playgrounds/tanstack-query/QueryCache.tsx
@@ -1,0 +1,294 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type CacheEntry = {
+  data: string
+  fetchedAt: number
+}
+
+type QueryState = {
+  status: 'idle' | 'loading' | 'success' | 'error'
+  data: string | null
+  isStale: boolean
+  fetchedAt: number | null
+}
+
+const STALE_TIME = 5000 // 5초 후 stale
+
+async function fetchUser(id: number): Promise<string> {
+  const delay = 600 + Math.random() * 600
+  await new Promise((r) => setTimeout(r, delay))
+  if (Math.random() < 0.15) throw new Error('network error')
+  const names = ['나래', '제리', '서연', '민준', '지우']
+  return `${names[(id - 1) % names.length]} (id=${id}, ${Math.round(delay)}ms)`
+}
+
+export default function QueryCache() {
+  const [activeId, setActiveId] = useState(1)
+  const [queries, setQueries] = useState<Record<number, QueryState>>({})
+  const [cache, setCache] = useState<Record<number, CacheEntry>>({})
+  const [networkCalls, setNetworkCalls] = useState(0)
+
+  const setQuery = (id: number, patch: Partial<QueryState>) => {
+    setQueries((prev) => {
+      const existing: QueryState = prev[id] ?? {
+        status: 'idle',
+        data: null,
+        isStale: false,
+        fetchedAt: null,
+      }
+      return { ...prev, [id]: { ...existing, ...patch } }
+    })
+  }
+
+  const load = async (id: number, force = false) => {
+    const cached = cache[id]
+    const now = Date.now()
+    const hasFresh = !force && cached && now - cached.fetchedAt < STALE_TIME
+
+    if (hasFresh) {
+      // 캐시 히트 — 네트워크 호출 없이 즉시
+      setQuery(id, {
+        status: 'success',
+        data: cached.data,
+        isStale: false,
+        fetchedAt: cached.fetchedAt,
+      })
+      return
+    }
+
+    // stale이면 캐시 먼저 보여주고 백그라운드 페치 (stale-while-revalidate)
+    if (cached) {
+      setQuery(id, {
+        status: 'loading',
+        data: cached.data,
+        isStale: true,
+        fetchedAt: cached.fetchedAt,
+      })
+    } else {
+      setQuery(id, {
+        status: 'loading',
+        data: null,
+        isStale: false,
+        fetchedAt: null,
+      })
+    }
+
+    setNetworkCalls((n) => n + 1)
+    try {
+      const data = await fetchUser(id)
+      const fetchedAt = Date.now()
+      setCache((prev) => ({ ...prev, [id]: { data, fetchedAt } }))
+      setQuery(id, {
+        status: 'success',
+        data,
+        isStale: false,
+        fetchedAt,
+      })
+    } catch {
+      setQuery(id, { status: 'error' })
+    }
+  }
+
+  useEffect(() => {
+    // 탭 변경 시 로드 트리거. mock 서버 상태 동기화이므로 의도된 side effect.
+    // load 함수를 deps에 넣으면 매 렌더마다 재실행이라 의도적으로 제외.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load(activeId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId])
+
+  const current = queries[activeId]
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <div className='flex flex-wrap gap-1 rounded-full bg-white p-1 ring-1 ring-gray-200'>
+          {[1, 2, 3, 4, 5].map((id) => {
+            const q = queries[id]
+            const cached = cache[id]
+            return (
+              <button
+                key={id}
+                type='button'
+                onClick={() => setActiveId(id)}
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-bold transition',
+                  activeId === id
+                    ? 'bg-[#ff5e48] text-white'
+                    : cached
+                      ? 'bg-emerald-100 text-emerald-800'
+                      : 'text-gray-500 hover:bg-gray-100'
+                )}
+              >
+                👤 User {id}
+                {q?.isStale && ' ⏱'}
+                {cached && !q?.isStale && activeId !== id && ' ✓'}
+              </button>
+            )
+          })}
+        </div>
+        <button
+          type='button'
+          onClick={() => load(activeId, true)}
+          className='rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-bold text-gray-700 hover:border-[#ff5e48]'
+        >
+          🔄 강제 새로고침
+        </button>
+        <button
+          type='button'
+          onClick={() => {
+            setCache({})
+            setQueries({})
+            setNetworkCalls(0)
+          }}
+          className='rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-bold text-gray-700 hover:border-red-500'
+        >
+          🗑️ 캐시 비우기
+        </button>
+      </div>
+
+      <div className='mb-4 grid grid-cols-2 gap-3 rounded-xl bg-white p-4 shadow-sm sm:grid-cols-4'>
+        <Stat
+          label='📡 네트워크 호출'
+          value={networkCalls}
+          hint='캐시 히트는 미포함'
+        />
+        <Stat
+          label='🗄️ 캐시 상태'
+          value={Object.keys(cache).length}
+          hint='저장된 user 수'
+        />
+        <Stat label='🎯 현재 status' value={current?.status ?? 'idle'} />
+        <Stat label='⏱ stale?' value={current?.isStale ? 'stale' : 'fresh'} />
+      </div>
+
+      <div className='mb-4 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <div className='mb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+          🙋 현재 사용자 데이터
+        </div>
+        {current?.status === 'loading' && !current.data && (
+          <div className='font-mono text-sm text-gray-400'>불러오는 중…</div>
+        )}
+        {current?.status === 'error' && (
+          <div className='font-mono text-sm text-red-500'>
+            네트워크 에러. 다시 시도하거나 캐시 비우기.
+          </div>
+        )}
+        {current?.data && (
+          <div className='font-mono text-lg font-bold'>
+            {current.data}{' '}
+            {current.isStale && (
+              <span className='ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] text-amber-800'>
+                stale — 뒤에서 refetch 중
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 탭을 User 1~5 왔다갔다 하며 네트워크 호출
+          카운트를 봐.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>1회차: 각 User 처음 방문 시 네트워크 호출 (loading)</li>
+          <li>2회차(5초 안): 캐시 히트 → 네트워크 호출 0, 즉시 표시</li>
+          <li>
+            2회차(5초 후): stale 상태. <b>캐시 먼저 보여주고</b> 뒤에서 refetch
+            (stale-while-revalidate)
+          </li>
+          <li>강제 새로고침: stale 여부와 무관하게 새 요청</li>
+        </ul>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ useEffect + useState 수동 구현',
+          code: `function UserCard({ id }: { id: number }) {
+  const [data, setData] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    setLoading(true)
+    fetchUser(id)
+      .then(d => setData(d))
+      .catch(e => setError(e))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  // 캐시도 없고, race condition 가드도 없고, dedup도 없음
+  if (loading) return '...'
+  return data
+}`,
+          takeaway:
+            '매 마운트마다 새 요청, 여러 컴포넌트가 같은 데이터를 중복 요청, race condition 취약',
+        }}
+        after={{
+          label: '✅ TanStack Query',
+          code: `function UserCard({ id }: { id: number }) {
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['user', id],
+    queryFn: () => fetchUser(id),
+    staleTime: 5_000,   // 5초는 fresh
+    gcTime: 5 * 60_000, // 5분 뒤 캐시 폐기
+  })
+
+  if (isPending) return '...'
+  if (isError) return '에러'
+  return data
+}`,
+          takeaway:
+            '캐시·dedup·refetch·stale 관리 모두 프레임워크가 담당. 코드는 &quot;뭘 원하는가&quot;만',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 TanStack Query의 4가지 핵심
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🗄️ <b>캐시</b> — queryKey 단위로 저장 · 구독. 같은 key 요청은 한
+            번만
+          </li>
+          <li>
+            🏃 <b>Refetch 정책</b> — focus 복귀 · 네트워크 회복 · mount 시 자동
+          </li>
+          <li>
+            ⏱️ <b>stale-while-revalidate</b> — 캐시 먼저 보여주고 뒤에서 갱신
+          </li>
+          <li>
+            🪄 <b>Mutation</b> — <code>useMutation</code> + optimistic update +{' '}
+            <code>invalidateQueries</code>로 관련 쿼리 자동 재시작
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string
+  value: string | number
+  hint?: string
+}) {
+  return (
+    <div>
+      <div className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
+        {label}
+      </div>
+      <div className='mt-0.5 font-mono text-lg font-bold'>{value}</div>
+      {hint && <div className='text-[10px] text-gray-400'>{hint}</div>}
+    </div>
+  )
+}

--- a/src/components/playgrounds/tanstack-query/index.tsx
+++ b/src/components/playgrounds/tanstack-query/index.tsx
@@ -1,0 +1,38 @@
+import GoalViz from './GoalViz'
+import QueryCache from './QueryCache'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function TanStackQueryPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              이 놀이기구는 TanStack Query를 &quot;흉내&quot; 낸 mock 이야
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              실제 라이브러리 없이도 캐시 · stale · 자동 refetch 개념을 눈으로
+              확인할 수 있게 가짜 fetch와 메모리 캐시로 시뮬레이션했어. 탭을
+              왔다갔다 하며 네트워크 호출이 언제 진짜 일어나는지 봐봐.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🗄️'
+        title='Query Cache 시뮬레이터'
+        description='가짜 fetch + 5초 staleTime + stale-while-revalidate 재현. User 탭을 왕복하며 캐시 히트/미스/백그라운드 refetch 관찰.'
+      >
+        <QueryCache />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usecontext/GoalViz.tsx
+++ b/src/components/playgrounds/usecontext/GoalViz.tsx
@@ -1,0 +1,146 @@
+import { ReactNode } from 'react'
+
+export default function UseContextGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          Context는 &quot;주입 통로&quot;, 상태 관리 아님.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🚇'
+          title='Context는 상태 관리 도구가 아니다'
+          hook='값을 깊이 전달하는 통로일 뿐'
+        >
+          <p>
+            Context가 하는 일은{' '}
+            <b>Provider에 꽂힌 값을 하위 트리 어디서든 꺼내쓰게</b> 해주는 것.
+            state를 &quot;만들어&quot; 주진 않아.
+          </p>
+          <p className='mt-2'>
+            state는 여전히 <code>useState</code>/<code>useReducer</code>로
+            관리하고, 그 값과 업데이트 함수를 Context로 내려보내는 구조야.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const ThemeContext = createContext<ThemeValue | null>(null)
+
+function Provider({ children }) {
+  const [theme, setTheme] = useState('light')   // ← state는 여기
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='📡'
+          title='Context의 리렌더 문제'
+          hook='value가 새 참조면 모든 구독자 리렌더'
+        >
+          <p>
+            Provider의 value가 <b>참조로 비교</b>돼. 매 렌더마다 인라인 객체로
+            넘기면 구독자 전원이 리렌더.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🔧 해결: <code>useMemo</code>/<code>useCallback</code>으로 안정화
+            </li>
+            <li>🔧 심화: Context를 여러 개로 쪼개기 (값 빈도별 분리)</li>
+            <li>
+              🔧 극단: <code>use-context-selector</code> 같은 셀렉터 패턴
+            </li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🎚️'
+          title='언제 Context / 언제 라이브러리'
+          hook='가벼운 전역값 = Context, 복잡한 상태 = 라이브러리'
+        >
+          <p>Context가 적합한 경우:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>✅ 테마 · 로케일 · 로그인 유저 정보 (드물게 바뀌는 전역값)</li>
+            <li>✅ 한두 Provider로 끝나는 작은 앱</li>
+            <li>✅ 디자인 시스템 테마 토큰 주입</li>
+          </ul>
+          <p className='mt-2'>라이브러리가 나은 경우:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>🌊 자주 바뀌는 값, 수십 개 컴포넌트가 선택적 구독</li>
+            <li>🌊 Devtools · 타임트래블 · 미들웨어 필요</li>
+            <li>🌊 서버 상태 (그땐 TanStack Query로)</li>
+          </ul>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🧩'
+          title='Provider 컴포지션 패턴'
+          hook='여러 Context를 섞어 쓸 때의 팁'
+        >
+          <p>
+            앱 루트에 Provider가 쌓이면 읽기 어려워져. 감싸는 헬퍼를 만들자.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`function AppProviders({ children }: Props) {
+  return (
+    <ThemeProvider>
+      <AuthProvider>
+        <ToastProvider>
+          {children}
+        </ToastProvider>
+      </AuthProvider>
+    </ThemeProvider>
+  )
+}`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            + 각 Provider는 자체 <code>useTheme</code> 같은 훅을 export해서
+            접근을 숨기면 더 안전해.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/usecontext/ThemeTree.tsx
+++ b/src/components/playgrounds/usecontext/ThemeTree.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import {
+  createContext,
+  memo,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type Theme = 'light' | 'dark'
+type ThemeContextValue = { theme: Theme; toggle: () => void }
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('ThemeContext missing')
+  return ctx
+}
+
+function LeafCard({ label }: { label: string }) {
+  const { theme } = useTheme()
+  const renders = useRef(0)
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl p-4 text-center ring-1 transition-colors',
+        theme === 'dark'
+          ? 'bg-gray-900 text-gray-100 ring-gray-700'
+          : 'bg-white text-gray-900 ring-gray-200'
+      )}
+    >
+      <div className='text-xs font-semibold tracking-wider uppercase opacity-70'>
+        {label}
+      </div>
+      <div className='mt-1 font-mono text-2xl font-extrabold'>
+        {theme === 'dark' ? '🌙' : '☀️'}
+      </div>
+      <div className='mt-1 text-[11px] opacity-70'>
+        {/* eslint-disable-next-line react-hooks/refs */}
+        렌더 {renders.current}
+      </div>
+    </div>
+  )
+}
+
+const NonSubscriber = memo(function NonSubscriberInner() {
+  const renders = useRef(0)
+  // eslint-disable-next-line react-hooks/refs
+  renders.current += 1
+  return (
+    <div className='rounded-xl border-2 border-dashed border-gray-200 p-4 text-center'>
+      <div className='text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+        Context 구독 안 함
+      </div>
+      <div className='mt-1 text-3xl'>🙉</div>
+      <div className='mt-1 text-[11px] text-gray-400'>
+        {/* eslint-disable-next-line react-hooks/refs */}
+        렌더 {renders.current}
+      </div>
+    </div>
+  )
+})
+
+function DeepBranch({ depth }: { depth: number }) {
+  if (depth === 0) {
+    return (
+      <div className='grid grid-cols-3 gap-3'>
+        <LeafCard label='Leaf A' />
+        <LeafCard label='Leaf B' />
+        <NonSubscriber />
+      </div>
+    )
+  }
+  return (
+    <div className='rounded-xl bg-gray-50 p-3'>
+      <div className='mb-2 text-[10px] font-semibold tracking-wider text-gray-400 uppercase'>
+        depth {depth}
+      </div>
+      <DeepBranch depth={depth - 1} />
+    </div>
+  )
+}
+
+export default function ThemeTree() {
+  const [theme, setTheme] = useState<Theme>('light')
+  const toggle = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+
+  // ❌ 매 렌더마다 새 객체 (context value 참조 변경 → 모든 구독자 리렌더)
+  const unstable: ThemeContextValue = { theme, toggle }
+  // ✅ useMemo로 참조 안정 (theme 변경 시에만 새 객체)
+  const stable = useMemo<ThemeContextValue>(() => ({ theme, toggle }), [theme])
+  const [useStable, setUseStable] = useState(true)
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={toggle}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🎛️ 테마 토글 (현재: {theme === 'dark' ? '🌙 다크' : '☀️ 라이트'})
+        </button>
+        <button
+          type='button'
+          onClick={() => setUseStable((v) => !v)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            useStable
+              ? 'bg-emerald-500 text-white'
+              : 'border border-red-300 bg-white text-red-600'
+          )}
+        >
+          {useStable ? '✅ value useMemo 켜짐' : '❌ value useMemo 꺼짐'}
+        </button>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: Provider 아래 깊은 트리(depth 3)의 말단 리프들.
+          테마 토글뿐 아니라 <b>무관한 state 변경 시에도</b> useMemo 없이는
+          value가 새 객체라 전부 리렌더돼.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            🟢 <b>Leaf A/B</b>: Context 구독 → 테마 바뀔 때 당연히 리렌더
+          </li>
+          <li>
+            🧊 <b>NonSubscriber</b>: memo로 감싼, context 구독 X → 거의 리렌더
+            없음 (Provider 부모 리렌더만 영향)
+          </li>
+        </ul>
+      </div>
+
+      <ThemeContext.Provider value={useStable ? stable : unstable}>
+        <DeepBranch depth={3} />
+      </ThemeContext.Provider>
+
+      <div className='mt-5'>
+        <BeforeAfter
+          before={{
+            label: '❌ 매 렌더마다 새 value',
+            code: `function ThemeProvider({ children }: Props) {
+  const [theme, setTheme] = useState('light')
+
+  // ❌ Provider 부모가 리렌더될 때마다 새 객체
+  const value = { theme, toggle: () => setTheme(t => t === 'light' ? 'dark' : 'light') }
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}`,
+            takeaway:
+              'Context value가 매번 새 참조 → 모든 구독자가 불필요하게 리렌더',
+          }}
+          after={{
+            label: '✅ useMemo/useCallback으로 안정',
+            code: `function ThemeProvider({ children }: Props) {
+  const [theme, setTheme] = useState('light')
+
+  const toggle = useCallback(
+    () => setTheme(t => t === 'light' ? 'dark' : 'light'),
+    []
+  )
+  const value = useMemo(() => ({ theme, toggle }), [theme, toggle])
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}`,
+            takeaway:
+              'theme이 진짜 바뀔 때만 value가 새 참조 → 구독자 리렌더 최소화',
+          }}
+        />
+      </div>
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 Context ≠ 상태 관리 라이브러리
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 Context는 <b>값 전달 도구</b>. 저장소가 아니야. state는 어차피{' '}
+            <code>useState</code>/<code>useReducer</code>에 있어.
+          </li>
+          <li>
+            🎯 <b>모든 구독자가 같은 값에 반응</b>. 일부만 구독하는 세밀한
+            업데이트가 필요하면 Zustand/Jotai 같은 라이브러리가 효율적.
+          </li>
+          <li>
+            🎯 자주 바뀌는 값(마우스 위치 등)은 Context에 안 맞음 — 트리 전체가
+            진동할 수 있어.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usecontext/index.tsx
+++ b/src/components/playgrounds/usecontext/index.tsx
@@ -1,0 +1,37 @@
+import GoalViz from './GoalViz'
+import ThemeTree from './ThemeTree'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseContextPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              깊은 트리까지 값을 내려보는 통로
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              Provider 아래 3단 깊이의 자식까지 테마가 내려가는 걸 확인. value
+              useMemo 토글로 리렌더 범위가 어떻게 바뀌는지도 함께.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🌲'
+        title='ThemeTree — Provider · 구독 · 리렌더'
+        description='Context Provider + 깊은 자식 + useMemo로 value 안정화. 구독자와 비구독자의 리렌더 횟수 차이까지 한눈에.'
+      >
+        <ThemeTree />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usereducer/GoalViz.tsx
+++ b/src/components/playgrounds/usereducer/GoalViz.tsx
@@ -1,0 +1,131 @@
+import { ReactNode } from 'react'
+
+export default function UseReducerGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          상태가 복잡해지면 &quot;변화의 이름&quot;을 붙이자.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='⚖️'
+          title='useState vs useReducer'
+          hook='state 개수보다 "변화의 복잡도"가 기준'
+        >
+          <p>useState와 useReducer는 둘 다 state를 관리. 선택 기준은:</p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              📦 <b>useState</b> — 독립적인 단일 값 · 간단한 토글
+            </li>
+            <li>
+              ⚙️ <b>useReducer</b> — 여러 state가 한 묶음 · 다양한 액션
+            </li>
+          </ul>
+          <p className='mt-3 text-[12px] text-gray-500'>
+            💡 &quot;toggle → filter 변경 → 완료 일괄 삭제&quot; 처럼 시나리오가
+            많아지면 reducer 쪽이 훨씬 읽기 좋음.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🧠'
+          title='복잡한 상태 로직 관리'
+          hook='state 업데이트를 한 곳으로 모은다'
+        >
+          <p>
+            useState 방식은 set 호출이 이벤트 핸들러마다 흩어져. 규칙이 깨지기
+            쉬움.
+          </p>
+          <p className='mt-2'>
+            reducer는 <b>모든 변화를 한 함수</b>에 모으고, 컴포넌트는 &quot;어떤
+            일이 일어났는지&quot;만 선언 (<code>dispatch</code>). 관심사 분리가
+            자연스러워.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='📮'
+          title='dispatch 패턴'
+          hook='액션은 "일어난 일"의 이름'
+        >
+          <p>
+            액션 타입은 도메인 이벤트로 이름 붙이자. <code>SET_TODOS</code>
+            같은 setter 이름은 reducer의 장점을 깎아먹어.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// ❌ 값만 덮어쓰는 표현
+dispatch({ type: 'SET_TODOS', payload: next })
+
+// ✅ 의미를 드러내는 액션
+dispatch({ type: 'add', text })
+dispatch({ type: 'toggle', id })
+dispatch({ type: 'clear-done' })`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🧪'
+          title='reducer는 순수 함수'
+          hook='테스트·디버깅 · 타임트래블이 쉽다'
+        >
+          <p>
+            reducer는 <b>(state, action) → newState</b> 순수 함수. 외부 의존
+            없음.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              🧪 유닛 테스트: <code>reducer(state, action)</code>만 호출
+            </li>
+            <li>
+              🔄 Redux Devtools · 타임트래블 디버깅 가능 (RTK와 같은 원리)
+            </li>
+            <li>
+              🚫 reducer 안에서는 API 호출·setState 호출 금지 (사이드 이펙트는
+              바깥에서)
+            </li>
+          </ul>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/usereducer/TodoReducer.tsx
+++ b/src/components/playgrounds/usereducer/TodoReducer.tsx
@@ -1,0 +1,335 @@
+'use client'
+
+import { useReducer, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type Todo = { id: number; text: string; done: boolean }
+type Filter = 'all' | 'active' | 'done'
+
+type Action =
+  | { type: 'add'; text: string }
+  | { type: 'toggle'; id: number }
+  | { type: 'remove'; id: number }
+  | { type: 'filter'; filter: Filter }
+  | { type: 'clear-done' }
+
+type State = { todos: Todo[]; filter: Filter; nextId: number }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'add':
+      return {
+        ...state,
+        todos: [
+          ...state.todos,
+          { id: state.nextId, text: action.text, done: false },
+        ],
+        nextId: state.nextId + 1,
+      }
+    case 'toggle':
+      return {
+        ...state,
+        todos: state.todos.map((t) =>
+          t.id === action.id ? { ...t, done: !t.done } : t
+        ),
+      }
+    case 'remove':
+      return {
+        ...state,
+        todos: state.todos.filter((t) => t.id !== action.id),
+      }
+    case 'filter':
+      return { ...state, filter: action.filter }
+    case 'clear-done':
+      return { ...state, todos: state.todos.filter((t) => !t.done) }
+    default:
+      return state
+  }
+}
+
+const INITIAL_STATE: State = {
+  todos: [
+    { id: 1, text: 'useMemo 스테이지 클리어', done: true },
+    { id: 2, text: '커스텀 훅 설계하기', done: false },
+    { id: 3, text: 'Zustand 코드 훑기', done: false },
+  ],
+  filter: 'all',
+  nextId: 4,
+}
+
+// useState 방식
+function UseStateTodo() {
+  const [todos, setTodos] = useState(INITIAL_STATE.todos)
+  const [filter, setFilter] = useState<Filter>('all')
+  const [nextId, setNextId] = useState(INITIAL_STATE.nextId)
+  const [draft, setDraft] = useState('')
+
+  const addTodo = () => {
+    if (!draft.trim()) return
+    setTodos([...todos, { id: nextId, text: draft.trim(), done: false }])
+    setNextId(nextId + 1)
+    setDraft('')
+  }
+  const toggle = (id: number) =>
+    setTodos(todos.map((t) => (t.id === id ? { ...t, done: !t.done } : t)))
+  const remove = (id: number) => setTodos(todos.filter((t) => t.id !== id))
+  const clearDone = () => setTodos(todos.filter((t) => !t.done))
+
+  return (
+    <TodoView
+      title='📦 useState 방식'
+      tone='gray'
+      todos={todos}
+      filter={filter}
+      draft={draft}
+      onDraft={setDraft}
+      onAdd={addTodo}
+      onToggle={toggle}
+      onRemove={remove}
+      onFilter={setFilter}
+      onClearDone={clearDone}
+    />
+  )
+}
+
+// useReducer 방식
+function UseReducerTodo() {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+  const [draft, setDraft] = useState('')
+
+  const addTodo = () => {
+    if (!draft.trim()) return
+    dispatch({ type: 'add', text: draft.trim() })
+    setDraft('')
+  }
+
+  return (
+    <TodoView
+      title='⚙️ useReducer 방식'
+      tone='purple'
+      todos={state.todos}
+      filter={state.filter}
+      draft={draft}
+      onDraft={setDraft}
+      onAdd={addTodo}
+      onToggle={(id) => dispatch({ type: 'toggle', id })}
+      onRemove={(id) => dispatch({ type: 'remove', id })}
+      onFilter={(filter) => dispatch({ type: 'filter', filter })}
+      onClearDone={() => dispatch({ type: 'clear-done' })}
+    />
+  )
+}
+
+type ViewProps = {
+  title: string
+  tone: 'gray' | 'purple'
+  todos: Todo[]
+  filter: Filter
+  draft: string
+  onDraft: (v: string) => void
+  onAdd: () => void
+  onToggle: (id: number) => void
+  onRemove: (id: number) => void
+  onFilter: (f: Filter) => void
+  onClearDone: () => void
+}
+
+function TodoView({
+  title,
+  tone,
+  todos,
+  filter,
+  draft,
+  onDraft,
+  onAdd,
+  onToggle,
+  onRemove,
+  onFilter,
+  onClearDone,
+}: ViewProps) {
+  const visible = todos.filter((t) => {
+    if (filter === 'active') return !t.done
+    if (filter === 'done') return t.done
+    return true
+  })
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl p-4 ring-1',
+        tone === 'purple'
+          ? 'bg-[#f5f3ff] ring-purple-200'
+          : 'bg-white ring-gray-200'
+      )}
+    >
+      <div
+        className={cn(
+          'mb-2 text-xs font-bold tracking-wider uppercase',
+          tone === 'purple' ? 'text-purple-700' : 'text-gray-600'
+        )}
+      >
+        {title}
+      </div>
+
+      <div className='mb-3 flex gap-2'>
+        <input
+          value={draft}
+          onChange={(e) => onDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onAdd()
+          }}
+          placeholder='할 일 추가'
+          className='flex-1 rounded-lg border border-gray-200 bg-white px-2 py-1 text-xs focus:border-[#ff5e48] focus:outline-none'
+        />
+        <button
+          type='button'
+          onClick={onAdd}
+          className='rounded-full bg-[#ff5e48] px-3 py-1 text-xs font-bold text-white hover:bg-[#ec4b36]'
+        >
+          ➕
+        </button>
+      </div>
+
+      <div className='mb-2 flex gap-1 text-[10px]'>
+        {(['all', 'active', 'done'] as Filter[]).map((f) => (
+          <button
+            key={f}
+            type='button'
+            onClick={() => onFilter(f)}
+            className={cn(
+              'rounded-full px-2 py-0.5 font-semibold transition',
+              filter === f
+                ? 'bg-gray-900 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            )}
+          >
+            {f}
+          </button>
+        ))}
+        <button
+          type='button'
+          onClick={onClearDone}
+          className='ml-auto rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-600 hover:bg-gray-200'
+        >
+          완료 비우기
+        </button>
+      </div>
+
+      <ul className='max-h-40 space-y-1 overflow-y-auto'>
+        {visible.map((t) => (
+          <li
+            key={t.id}
+            className='flex items-center gap-2 rounded-md bg-white px-2 py-1 text-xs ring-1 ring-gray-100'
+          >
+            <input
+              type='checkbox'
+              checked={t.done}
+              onChange={() => onToggle(t.id)}
+              className='cursor-pointer'
+            />
+            <span
+              className={cn('flex-1', t.done && 'text-gray-400 line-through')}
+            >
+              {t.text}
+            </span>
+            <button
+              type='button'
+              onClick={() => onRemove(t.id)}
+              className='text-gray-300 hover:text-red-500'
+              aria-label='삭제'
+            >
+              ×
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default function TodoReducer() {
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 두 Todo 모두 동일한 기능이야. 양쪽을 조작하며
+          어느 쪽 코드 관리가 편할지 직관적으로 느껴봐.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            📦 <b>useState</b>: todos, filter, nextId 3개 state를 각자 관리.
+            이벤트 핸들러마다 2~3번씩 <code>setX</code> 호출.
+          </li>
+          <li>
+            ⚙️ <b>useReducer</b>: 모든 state를 한 객체로 모으고, 변화는 액션으로
+            표현. 컴포넌트는 <code>dispatch</code>만 하면 됨.
+          </li>
+        </ul>
+      </div>
+
+      <div className='mb-4 grid gap-3 md:grid-cols-2'>
+        <UseStateTodo />
+        <UseReducerTodo />
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ 여러 state가 흩어진 useState',
+          code: `const [todos, setTodos] = useState<Todo[]>([])
+const [filter, setFilter] = useState<Filter>('all')
+const [nextId, setNextId] = useState(1)
+
+const addTodo = () => {
+  setTodos([...todos, { id: nextId, text, done: false }])
+  setNextId(nextId + 1)
+  setText('')
+}
+
+const toggle = (id: number) =>
+  setTodos(todos.map(t => t.id === id ? { ...t, done: !t.done } : t))`,
+          takeaway:
+            '상태가 커질수록 set 호출이 여러 곳에서 흩어짐. 규칙성을 잃기 쉬움',
+        }}
+        after={{
+          label: '✅ 액션 + reducer로 변화 모으기',
+          code: `type Action =
+  | { type: 'add'; text: string }
+  | { type: 'toggle'; id: number }
+  | { type: 'filter'; filter: Filter }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'add': return { ...state, todos: [...], nextId: ... }
+    case 'toggle': return { ...state, todos: state.todos.map(...) }
+    case 'filter': return { ...state, filter: action.filter }
+  }
+}
+
+const [state, dispatch] = useReducer(reducer, initialState)
+// 컴포넌트 쪽에선 dispatch({ type: 'toggle', id })만`,
+          takeaway:
+            '변화 종류가 타입 시스템으로 강제됨. 테스트도 순수 reducer 단위로 쉬움',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 useState vs useReducer 선택 기준
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            📦 <b>useState</b> — 1~2개 state, 변화가 단순, 로컬 폼 같은 경우
+          </li>
+          <li>
+            ⚙️ <b>useReducer</b> — 3+ state가 얽힘, 변화가 액션 타입별로 분명,
+            테스트·타임트래블이 필요할 때
+          </li>
+          <li>
+            🌊 전역이 되면? → Context + Reducer, 또는 Zustand/RTK 등 라이브러리.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/usereducer/index.tsx
+++ b/src/components/playgrounds/usereducer/index.tsx
@@ -1,0 +1,36 @@
+import GoalViz from './GoalViz'
+import TodoReducer from './TodoReducer'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function UseReducerPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>같은 Todo, 두 가지 방식</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              왼쪽은 useState로, 오른쪽은 useReducer로 구현한 똑같은 Todo야.
+              추가 · 토글 · 필터 · 일괄 삭제를 양쪽에서 조작하며 어느 쪽이 더
+              읽기 좋은지 체감해봐.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='📋'
+        title='Todo 리스트 — useState vs useReducer'
+        description='추가/토글/필터/완료 일괄 삭제를 같은 UI에 구현한 두 버전. 상태가 3개 이상 묶일 때 reducer가 빛을 발한다.'
+      >
+        <TodoReducer />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/data/playgrounds.ts
+++ b/src/data/playgrounds.ts
@@ -11,6 +11,10 @@ import UseEffectPlayground from '@/components/playgrounds/useeffect'
 import CustomHooksPlayground from '@/components/playgrounds/custom-hooks'
 import UseRefPlayground from '@/components/playgrounds/useref'
 import ErrorBoundaryPlayground from '@/components/playgrounds/error-boundary'
+import UseContextPlayground from '@/components/playgrounds/usecontext'
+import UseReducerPlayground from '@/components/playgrounds/usereducer'
+import TanStackQueryPlayground from '@/components/playgrounds/tanstack-query'
+import StateLibsPlayground from '@/components/playgrounds/state-libs'
 
 export const playgrounds: Record<string, ComponentType> = {
   // 🎣 훅
@@ -27,6 +31,11 @@ export const playgrounds: Record<string, ComponentType> = {
   'stage-react-compiler': ReactCompilerPlayground,
   'boss-rendering': BossRenderingPlayground,
   'stage-perf-advanced': PerfAdvancedPlayground,
+  // 🗂 상태 관리
+  'stage-9-usecontext': UseContextPlayground,
+  'stage-10-usereducer': UseReducerPlayground,
+  'stage-tanstack-query': TanStackQueryPlayground,
+  'stage-state-libs': StateLibsPlayground,
 }
 
 export const hasPlayground = (stageId: string): boolean =>


### PR DESCRIPTION
closes #21

🗂 상태 관리 탭 **4/4** 플레이 가능 달성.

## 스테이지

- **useContext** (`/stages/stage-9-usecontext`) — ThemeTree (Provider + 깊은 자식 + value useMemo 토글로 리렌더 범위 시각화)
- **useReducer** (`/stages/stage-10-usereducer`) — TodoReducer (같은 Todo를 useState vs useReducer 병렬 구현)
- **TanStack Query** (`/stages/stage-tanstack-query`) — QueryCache mock 구현 (staleTime · stale-while-revalidate · 네트워크 호출 카운트)
- **Zustand / Jotai / RTK** (`/stages/stage-state-libs`) — CounterComparison (같은 카운터 3가지 방식 + 설치/코드/장단점)

## 전체 현황 (16/28)

- 🎣 훅: 6/6 ✅
- ⚡ 성능 ⭐: 6/6 ✅
- 🗂 상태 관리: **4/4** ✅
- 🌊 API: 0/6
- 🛠 인프라: 0/6

## 다음

Batch 5 — 🌊 API 탭 6개 (Suspense+use · React 19 Actions · Next.js App Router · Next.js 라우팅 · Server vs Client fetching · Auth 패턴)
