### PR TITLE
✨ Feature: API 탭 6개 놀이기구

### DIFF
--- a/src/components/playgrounds/app-router/GoalViz.tsx
+++ b/src/components/playgrounds/app-router/GoalViz.tsx
@@ -1,0 +1,119 @@
+import { ReactNode } from 'react'
+
+export default function AppRouterGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          Next.js App Router의 4가지 기초.
+        </p>
+      </header>
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🖥️'
+          title='Server vs Client 컴포넌트'
+          hook='기본은 서버, 상호작용만 클라'
+        >
+          <p>
+            App Router 파일의 <b>기본</b>은 Server Component. DB · 환경변수 ·
+            비밀값을 바로 쓸 수 있고, 클라이언트 번들에 안 들어가.
+          </p>
+          <p className='mt-2'>
+            <code>useState</code>·<code>onClick</code>·브라우저 API가 필요하면
+            그 파일만 <code>&quot;use client&quot;</code>로 꺼내.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🚪'
+          title="'use client' 경계 설정"
+          hook='지시어는 파일 단위, 전염되듯 퍼진다'
+        >
+          <p>
+            <code>&quot;use client&quot;</code>가 붙은 파일에서 import한
+            파일들도 자동으로 클라 번들에 포함돼. 경계는{' '}
+            <b>가능한 안쪽(leaf)에</b> 둬.
+          </p>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            💡 규칙: 서버 컴포넌트는 클라 컴포넌트를 props로 넘길 수 있지만, 그
+            반대는 안 됨 (children으로는 가능).
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='📨'
+          title='Server Actions'
+          hook='form이 곧 서버 함수 호출'
+        >
+          <p>
+            <code>&quot;use server&quot;</code> 지시어로 만든 함수를 form의{' '}
+            <code>action</code>에 연결. JS 없이도 submit 되고 있으면 더
+            부드럽게.
+          </p>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            React 19 Actions(useActionState/useOptimistic/useFormStatus)와 짝.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🗄️'
+          title='캐싱 전략 (fetch + revalidate)'
+          hook='기본 캐시 · revalidate · tags · no-store'
+        >
+          <p>
+            Server Component의 <code>fetch</code>는 기본이 캐시 대상.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>
+              ⏱ <code>{`{ next: { revalidate: 60 } }`}</code> 시간 기반
+            </li>
+            <li>
+              🏷 <code>{`{ next: { tags: ['posts'] } }`}</code> +{' '}
+              <code>revalidateTag</code>
+            </li>
+            <li>
+              🔥 <code>{`{ cache: 'no-store' }`}</code> 매 요청마다 새로
+            </li>
+          </ul>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/app-router/index.tsx
+++ b/src/components/playgrounds/app-router/index.tsx
@@ -1,0 +1,167 @@
+import CardPlayground, {
+  type CardPlaygroundItem,
+} from '@/components/stages/CardPlayground'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+import GoalViz from './GoalViz'
+
+const CARDS: CardPlaygroundItem[] = [
+  {
+    id: 'rsc-vs-client',
+    emoji: '🖥️',
+    title: 'Server vs Client 컴포넌트',
+    subtitle: '기본은 서버 · 필요할 때만 클라',
+    tagline: '원칙: "최소한의 use client"',
+    filename: 'server-vs-client.tsx',
+    code: `// app/posts/page.tsx — 기본은 Server Component (파일에 아무 것도 없어도 됨)
+import { db } from '@/lib/db'
+import LikeButton from './LikeButton'
+
+export default async function PostsPage() {
+  const posts = await db.post.findMany()   // 서버에서 직접 DB 접근
+  return (
+    <ul>
+      {posts.map(p => (
+        <li key={p.id}>
+          {p.title}
+          <LikeButton id={p.id} />  {/* 클라이언트 컴포넌트 */}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// LikeButton.tsx
+'use client'
+import { useState } from 'react'
+export default function LikeButton({ id }: { id: number }) {
+  const [liked, setLiked] = useState(false)
+  return <button onClick={() => setLiked(!liked)}>{liked ? '❤️' : '🤍'}</button>
+}`,
+    note: 'Server 컴포넌트에서 DB·파일·비밀값에 직접 접근 가능 — 클라이언트로 JS가 안 가. 상호작용 필요한 리프만 "use client"로 꺼냄.',
+  },
+  {
+    id: 'use-client-boundary',
+    emoji: '🚪',
+    title: "'use client' 경계",
+    subtitle: '지시어 한 줄이 모든 걸 바꾼다',
+    tagline: '파일 최상단에만 유효',
+    filename: 'boundary.tsx',
+    code: `// ❌ 잘못된 예
+// 서버 컴포넌트 안에서 useState 호출하면 빌드 에러
+import { useState } from 'react'
+export default function Page() {
+  const [n, setN] = useState(0)  // 💥 Error
+  return <div>{n}</div>
+}
+
+// ✅ 올바른 분리
+// Counter.tsx
+'use client'
+import { useState } from 'react'
+export default function Counter() {
+  const [n, setN] = useState(0)
+  return <button onClick={() => setN(n + 1)}>{n}</button>
+}
+
+// page.tsx (Server)
+import Counter from './Counter'
+export default function Page() {
+  return <div><Counter /></div>  // ✅ 클라 컴포넌트를 서버에서 import OK
+}`,
+    note: '"use client"가 붙은 파일과 그 import 트리는 클라 번들. 그렇지 않은 파일은 서버 번들. 경계는 파일 단위야.',
+  },
+  {
+    id: 'server-actions',
+    emoji: '📨',
+    title: 'Server Actions',
+    subtitle: '폼 submit이 곧 서버 함수 호출',
+    tagline: 'RPC 없이 타입 안전한 mutation',
+    filename: 'server-actions.tsx',
+    code: `// app/posts/actions.ts
+'use server'
+
+import { db } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+
+export async function createPost(formData: FormData) {
+  const title = formData.get('title')?.toString() ?? ''
+  await db.post.create({ data: { title } })
+  revalidatePath('/posts')   // 캐시 무효화 → 다음 요청 새로 가져옴
+}
+
+// app/posts/new/page.tsx
+import { createPost } from '../actions'
+
+export default function NewPostPage() {
+  return (
+    <form action={createPost}>
+      <input name='title' required />
+      <button type='submit'>발행</button>
+    </form>
+  )
+}`,
+    note: '폼이 JS 없이도 작동하는 기본(progressive enhancement) + JS 있으면 navigate 없이 부드럽게. revalidatePath/revalidateTag로 관련 페이지 자동 재생성.',
+  },
+  {
+    id: 'caching',
+    emoji: '🗄️',
+    title: '캐싱 전략 (fetch + revalidate)',
+    subtitle: '기본 캐시 · 수명 · 태그 기반 무효화',
+    tagline: 'Server Component fetch는 기본 캐시',
+    filename: 'caching.tsx',
+    code: `// 1) 기본 — 빌드 타임에 fetch, 이후 영구 캐시
+const posts = await fetch('https://api.example.com/posts')
+
+// 2) 시간 기반 재검증 — 60초마다 새로
+const posts = await fetch(url, { next: { revalidate: 60 } })
+
+// 3) 태그 기반 재검증 — 수동으로 무효화
+const posts = await fetch(url, { next: { tags: ['posts'] } })
+
+// Server Action에서
+'use server'
+import { revalidateTag } from 'next/cache'
+export async function addPost(data) {
+  await db.post.create({ data })
+  revalidateTag('posts')   // 위의 fetch가 다음 요청 때 재실행
+}
+
+// 4) 매 요청마다 새로 (캐시 off)
+const live = await fetch(url, { cache: 'no-store' })`,
+    note: 'Next.js 15+에서는 기본 캐시 정책이 보수적으로 바뀜. 필요한 만큼만 명시적으로 캐시하고 revalidate · no-store로 튜닝.',
+  },
+]
+
+export default function AppRouterPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              서버 컴포넌트의 새 세계 — 4카드 훑기
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              Server/Client 경계, Server Actions, 캐싱 전략을 코드로 한 장씩
+              카드 넘기며 감 잡자. 모든 예제는 Next.js 16 App Router 기준.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🖥️'
+        title='App Router 4시나리오'
+        description='서버/클라이언트 · use client 경계 · Server Actions · 캐싱.'
+      >
+        <CardPlayground items={CARDS} />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/auth-patterns/GoalViz.tsx
+++ b/src/components/playgrounds/auth-patterns/GoalViz.tsx
@@ -1,0 +1,119 @@
+import { ReactNode } from 'react'
+
+export default function AuthPatternsGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          Auth.js v5로 최소한의 조각 맞추기.
+        </p>
+      </header>
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🔐'
+          title='Auth.js v5 (NextAuth)'
+          hook='Next.js 공식 권장 인증'
+        >
+          <p>
+            env에 Provider 키만 넣으면 기본 동작. Server/Client 어디서든{' '}
+            <code>auth()</code>로 세션 확인.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='2'
+          emoji='⚖️'
+          title='JWT vs Session'
+          hook='stateless vs 서버 보관'
+        >
+          <p>
+            JWT — 서명 토큰을 클라가 보관, 서버는 stateless. Session —
+            서버(Redis/DB)가 원본, 클라는 session id만. 시작은 JWT, 강제
+            로그아웃 필요하면 DB 전략.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='3'
+          emoji='🚦'
+          title='Protected Routes (Middleware)'
+          hook='라우트 진입 전 가드'
+        >
+          <p>
+            <code>middleware.ts</code>에서 auth 체크하면 Edge 런타임이라 빠름.
+            미로그인 → redirect, 로그인 → 통과.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='4'
+          emoji='🌐'
+          title='OAuth (GitHub · Google)'
+          hook='콜백 URL이 핵심'
+        >
+          <p>
+            Provider 콘솔의 &quot;Authorization callback URL&quot;을{' '}
+            <code>/api/auth/callback/&lt;provider&gt;</code>로 정확히 맞추는 게
+            포인트.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='5'
+          emoji='🎭'
+          title='Role-based Access Control'
+          hook='session에 role 추가'
+        >
+          <p>
+            Auth.js의 <code>jwt</code>·<code>session</code> 콜백에서 role을 실어
+            나르고, 페이지/미들웨어에서 체크. 권한 매트릭스가 커지면 유틸 함수로
+            추출.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='6'
+          emoji='🔒'
+          title='보안 체크리스트'
+          hook='실전에서 빠뜨리면 안 되는 것'
+        >
+          <ul className='space-y-1 text-[13px]'>
+            <li>🛡️ CSRF — Auth.js가 기본 방어</li>
+            <li>🛡️ Secure · HttpOnly 쿠키</li>
+            <li>🛡️ Rate limit — Middleware 또는 Edge function</li>
+            <li>🛡️ 비밀번호는 bcrypt/argon2 해시 (저장 X)</li>
+          </ul>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/auth-patterns/index.tsx
+++ b/src/components/playgrounds/auth-patterns/index.tsx
@@ -1,0 +1,201 @@
+import CardPlayground, {
+  type CardPlaygroundItem,
+} from '@/components/stages/CardPlayground'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+import GoalViz from './GoalViz'
+
+const CARDS: CardPlaygroundItem[] = [
+  {
+    id: 'nextauth-setup',
+    emoji: '🔐',
+    title: 'NextAuth.js (Auth.js v5) 셋업',
+    subtitle: '2026년 Next.js 공식 권장 인증 라이브러리',
+    filename: 'auth.ts / route handlers',
+    code: `// auth.ts (프로젝트 루트)
+import NextAuth from 'next-auth'
+import GitHub from 'next-auth/providers/github'
+import Google from 'next-auth/providers/google'
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    GitHub({ clientId: process.env.GITHUB_ID!, clientSecret: process.env.GITHUB_SECRET! }),
+    Google,
+  ],
+  pages: { signIn: '/login' },
+})
+
+// app/api/auth/[...nextauth]/route.ts
+export { GET, POST } from '@/auth'
+export { handlers as runtime } from '@/auth'
+
+// Server Component에서 세션 읽기
+import { auth } from '@/auth'
+export default async function Page() {
+  const session = await auth()
+  if (!session) return <p>로그인 필요</p>
+  return <p>안녕 {session.user?.name}</p>
+}`,
+    note: 'Auth.js v5는 Edge 런타임 호환 + App Router에 자연스러움. env에 Provider 키만 넣으면 기본 구성 완성.',
+  },
+  {
+    id: 'jwt-vs-session',
+    emoji: '⚖️',
+    title: 'JWT vs Session',
+    subtitle: '어디에 저장하고, 어떻게 검증할지',
+    filename: '비교',
+    code: `🔑 JWT (JSON Web Token)
+- 서버가 서명한 토큰을 클라이언트가 보관
+- 서버는 stateless — 토큰 검증만
+- 장점: 수평 확장 쉬움, 마이크로서비스 간 편함
+- 단점: 만료 전 철회 어려움, 사이즈 큼
+
+🎫 Session (서버 세션)
+- 서버가 session id만 쿠키로 내려줌, 데이터는 서버(Redis/DB)
+- 장점: 철회 즉시 가능, 데이터 변경 유연
+- 단점: 서버 상태 유지 필요, 수평 확장 시 세션 저장소 공유
+
+Auth.js 기본 — "JWT 전략" (stateless, 자체 서명)
+Auth.js "database 전략" — Prisma 어댑터로 세션 테이블 관리
+
+// auth.ts에서 전략 선택
+export const { auth } = NextAuth({
+  session: { strategy: 'jwt' },       // 또는 'database'
+  // ...
+})`,
+    lang: 'text',
+    note: '대부분 JWT로 시작. 로그아웃 즉시 만료 · 강제 로그아웃 · 디바이스 관리가 중요하면 database 전략 고려.',
+  },
+  {
+    id: 'middleware-guard',
+    emoji: '🚦',
+    title: 'Protected Routes (Middleware)',
+    subtitle: '라우트 진입 전 인증 가드',
+    filename: 'middleware.ts',
+    code: `import NextAuth from 'next-auth'
+import authConfig from '@/auth.config'
+
+const { auth } = NextAuth(authConfig)
+
+export default auth((req) => {
+  const { nextUrl } = req
+  const isLoggedIn = !!req.auth
+  const isOnDashboard = nextUrl.pathname.startsWith('/dashboard')
+
+  if (isOnDashboard && !isLoggedIn) {
+    return Response.redirect(new URL('/login', nextUrl))
+  }
+  if (isOnDashboard && isLoggedIn) {
+    return  // 통과
+  }
+
+  return
+})
+
+export const config = {
+  matcher: ['/((?!api|_next|static|.*\\..*).*)'],
+}`,
+    note: 'Middleware는 Edge 런타임이라 빠름. 전체 앱 인증 가드의 표준 위치.',
+  },
+  {
+    id: 'oauth',
+    emoji: '🌐',
+    title: 'OAuth (GitHub · Google)',
+    subtitle: 'Provider 설정 + callback URL',
+    filename: '.env + 플로우',
+    code: `# .env.local
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=$(openssl rand -base64 32)
+
+# GitHub OAuth
+GITHUB_ID=xxxx
+GITHUB_SECRET=yyyy
+
+# Google OAuth
+AUTH_GOOGLE_ID=zzzz.apps.googleusercontent.com
+AUTH_GOOGLE_SECRET=...
+
+플로우:
+1. 사용자 → /api/auth/signin/github
+2. GitHub에 리다이렉트 → 동의
+3. GitHub → /api/auth/callback/github?code=...
+4. Auth.js가 code로 토큰 교환 + user 정보 fetch
+5. 세션 쿠키 세팅 → 원래 페이지로
+
+Provider 콘솔 설정:
+  Homepage URL: http://localhost:3000
+  Authorization callback URL:
+    http://localhost:3000/api/auth/callback/github`,
+    lang: 'text',
+    note: 'callback URL이 Provider 콘솔과 정확히 일치해야 함. 프로덕션용 · dev용 각각 등록.',
+  },
+  {
+    id: 'rbac',
+    emoji: '🎭',
+    title: 'Role-based Access Control',
+    subtitle: '사용자 역할에 따른 권한 분기',
+    filename: '권한 체크 패턴',
+    code: `// session에 role 추가
+// auth.ts
+export const { auth } = NextAuth({
+  callbacks: {
+    async session({ session, token }) {
+      if (token.role) session.user.role = token.role as string
+      return session
+    },
+    async jwt({ token, user }) {
+      if (user) token.role = (user as { role?: string }).role
+      return token
+    },
+  },
+})
+
+// Server Component에서 체크
+import { auth } from '@/auth'
+import { redirect } from 'next/navigation'
+
+export default async function AdminPage() {
+  const session = await auth()
+  if (!session) redirect('/login')
+  if (session.user.role !== 'admin') redirect('/forbidden')
+  return <AdminDashboard />
+}
+
+// Middleware에서도 가능
+if (pathname.startsWith('/admin') && token.role !== 'admin') {
+  return Response.redirect(new URL('/forbidden', req.url))
+}`,
+    note: '역할이 많아지면 권한 매트릭스를 유틸 함수로 분리 (<code>can(user, &apos;posts:delete&apos;)</code> 형태).',
+  },
+]
+
+export default function AuthPatternsPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>로그인·권한 · 5카드</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              Auth.js v5 기준으로 설치 · JWT vs Session · Middleware 가드 ·
+              OAuth · RBAC를 빠르게 훑기.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🔐'
+        title='Auth 5카드'
+        description='NextAuth 셋업 · JWT vs Session · Middleware 가드 · OAuth 플로우 · Role-based Access.'
+      >
+        <CardPlayground items={CARDS} />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/data-fetching/GoalViz.tsx
+++ b/src/components/playgrounds/data-fetching/GoalViz.tsx
@@ -1,0 +1,115 @@
+import { ReactNode } from 'react'
+
+export default function DataFetchingGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          데이터는 서버에서, 상호작용은 클라에서.
+        </p>
+      </header>
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🖥️'
+          title='Server Component fetch'
+          hook='초기 로드·SEO 최적'
+        >
+          <p>
+            서버에서 fetch → HTML에 데이터 포함. 브라우저 JS 번들 작고 LCP 빨라.
+            기본 캐시 정책은 <code>revalidate</code>로 세밀하게.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='2'
+          emoji='🌐'
+          title='Client TanStack Query'
+          hook='인터랙션·폴링·무한 스크롤'
+        >
+          <p>
+            사용자별 상태·무한 스크롤·자주 바뀌는 값. 서버가 초기 데이터를 넘겨
+            hydrate하면 첫 로드도 빠름.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='3'
+          emoji='🌊'
+          title='Streaming SSR'
+          hook='빠른 부분부터 흘려보내기'
+        >
+          <p>
+            Suspense boundary 단위로 HTML이 조각나서 전송. 느린 부분이 빠른
+            부분을 막지 않음. TTFB·LCP 개선.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='4'
+          emoji='⏱'
+          title='Revalidation 전략'
+          hook='시간·태그·경로로 무효화'
+        >
+          <p>
+            ISR은 시간 기반, 태그는 사용자 액션 즉시 반영, <code>no-store</code>
+            는 매 요청 새로. 각각 성격이 달라 혼합 가능.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='5'
+          emoji='⚡'
+          title='Optimistic Update'
+          hook='UI 먼저 바꾸고 서버 확인은 나중'
+        >
+          <p>
+            <code>useOptimistic</code> 훅이 서버 응답 실패 시 자동 롤백.
+            좋아요·북마크 같은 &quot;빨라야 하는&quot; UX에.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='6'
+          emoji='✏️'
+          title='Mutation 패턴'
+          hook='변경 + 관련 쿼리 재시작'
+        >
+          <p>
+            TanStack Query의 <code>useMutation</code>은 optimistic + error
+            rollback + invalidate 세트. Server Action이면{' '}
+            <code>revalidateTag</code>가 동일 역할.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/data-fetching/index.tsx
+++ b/src/components/playgrounds/data-fetching/index.tsx
@@ -1,0 +1,198 @@
+import CardPlayground, {
+  type CardPlaygroundItem,
+} from '@/components/stages/CardPlayground'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+import GoalViz from './GoalViz'
+
+const CARDS: CardPlaygroundItem[] = [
+  {
+    id: 'server-fetch',
+    emoji: '🖥️',
+    title: 'Server Component에서 fetch',
+    subtitle: 'SEO · 초기 로드 ↑ · 브라우저 JS ↓',
+    filename: 'app/posts/page.tsx',
+    code: `// Server Component (기본)
+export default async function PostsPage() {
+  const posts = await fetch('https://api.example.com/posts', {
+    next: { revalidate: 60 },   // ISR 60초
+  }).then(r => r.json())
+
+  return <PostList items={posts} />
+}`,
+    note: '서버에서 fetch → HTML로 하이드레이션. SEO·첫 페인트 최적. JS 번들에 fetch 코드·응답 데이터가 들어가지 않아.',
+    pros: ['✅ SEO 친화', '✅ JS 번들 작음', '✅ DB·API키 안전'],
+    cons: ['⚠️ 사용자별 인터랙션 필요하면 클라 조합 필요'],
+  },
+  {
+    id: 'client-query',
+    emoji: '🌐',
+    title: 'Client + TanStack Query',
+    subtitle: '사용자 상호작용 · 폴링 · 무한 스크롤',
+    filename: 'components/InfinitePosts.tsx',
+    code: `'use client'
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+export default function InfinitePosts() {
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: ['posts'],
+    queryFn: ({ pageParam = 0 }) =>
+      fetch('/api/posts?cursor=' + pageParam).then(r => r.json()),
+    getNextPageParam: (last) => last.nextCursor,
+    initialPageParam: 0,
+  })
+
+  return (
+    <div>
+      {data?.pages.flatMap(p => p.items).map(post => <Card key={post.id} {...post} />)}
+      {hasNextPage && <button onClick={() => fetchNextPage()}>더 보기</button>}
+    </div>
+  )
+}`,
+    note: '클라이언트 상태 · 캐시 · dedup · refetch 정책이 필요할 때. 서버가 준비한 초기 데이터를 hydrate로 넘겨주면 첫 로드도 빠름.',
+    pros: ['✅ 세밀한 캐시 제어', '✅ 인터랙션과 잘 맞음'],
+    cons: ['⚠️ JS 번들 ↑', '⚠️ 중복 상태 관리 주의'],
+  },
+  {
+    id: 'streaming',
+    emoji: '🌊',
+    title: 'Streaming SSR',
+    subtitle: '느린 부분은 Suspense로 미루고 흘려보내기',
+    filename: 'app/dashboard/page.tsx',
+    code: `import { Suspense } from 'react'
+
+export default function Dashboard() {
+  return (
+    <>
+      <FastHeader />
+
+      {/* 빠른 것부터 HTML로 흘러나옴 */}
+      <Suspense fallback={<StatsSkeleton />}>
+        <SlowStats />   {/* 내부에서 긴 DB 쿼리 */}
+      </Suspense>
+
+      <Suspense fallback={<ChartsSkeleton />}>
+        <SlowCharts />
+      </Suspense>
+    </>
+  )
+}`,
+    note: 'Suspense boundary가 스트리밍의 단위. 페이지 전체가 준비될 때까지 기다리지 않고 완성된 부분부터 보냄. TTFB·LCP 개선.',
+  },
+  {
+    id: 'revalidation',
+    emoji: '⏱',
+    title: 'Revalidation 전략',
+    subtitle: '시간 기반 · 태그 기반 · 수동',
+    filename: 'fetch + revalidate',
+    code: `// 1) 시간 기반 — 60초마다 재생성
+fetch(url, { next: { revalidate: 60 } })
+
+// 2) 태그 기반 — 데이터 변경 시 즉시 무효화
+fetch(url, { next: { tags: ['posts'] } })
+
+// Server Action에서 무효화
+'use server'
+import { revalidateTag, revalidatePath } from 'next/cache'
+
+export async function createPost(formData: FormData) {
+  await db.post.create({...})
+  revalidateTag('posts')         // 'posts' 태그 쓰는 모든 fetch 무효화
+  revalidatePath('/posts')        // 특정 경로 재생성
+}
+
+// 3) 비활성화 — 매번 새로
+fetch(url, { cache: 'no-store' })`,
+    note: 'on-demand revalidation으로 CMS 업데이트 · 사용자 action 이후 즉각 반영. 태그 기반이 세밀함.',
+  },
+  {
+    id: 'optimistic',
+    emoji: '⚡',
+    title: 'Optimistic Update',
+    subtitle: '서버 응답 전에 UI 선반영',
+    filename: 'components/LikeButton.tsx',
+    code: `'use client'
+import { useOptimistic, startTransition } from 'react'
+import { togglePostLike } from './actions'
+
+export default function LikeButton({ post }: { post: Post }) {
+  const [optimistic, addOptimistic] = useOptimistic(
+    post,
+    (current, _: void) => ({
+      ...current,
+      liked: !current.liked,
+      likes: current.liked ? current.likes - 1 : current.likes + 1,
+    })
+  )
+
+  const onClick = () => {
+    startTransition(() => {
+      addOptimistic()            // 즉시 UI
+      togglePostLike(post.id)    // Server Action
+    })
+  }
+
+  return <button onClick={onClick}>{optimistic.liked ? '❤️' : '🤍'} {optimistic.likes}</button>
+}`,
+    note: '사용자가 &quot;느리다&quot;고 느끼는 순간을 제거. 실패 시 React가 자동으로 롤백.',
+  },
+  {
+    id: 'mutation',
+    emoji: '✏️',
+    title: 'Mutation 패턴',
+    subtitle: '서버 변경 + 관련 쿼리 재시작',
+    filename: 'useMutation 패턴',
+    code: `// TanStack Query useMutation
+'use client'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+export function useDeletePost() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => fetch('/api/posts/' + id, { method: 'DELETE' }),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ['posts'] })
+      const prev = qc.getQueryData<Post[]>(['posts'])
+      qc.setQueryData<Post[]>(['posts'], (old = []) => old.filter(p => p.id !== id))
+      return { prev }
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['posts'], ctx.prev)  // 롤백
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ['posts'] }),
+  })
+}`,
+    note: 'mutation + optimistic + invalidate 한 세트. Next.js Server Action을 쓰면 이 역할을 revalidate/revalidatePath가 담당.',
+  },
+]
+
+export default function DataFetchingPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>언제 서버, 언제 클라이언트?</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              fetch 할 위치 · 캐싱 · streaming · optimistic · mutation을 6장
+              카드로. 상황별 최소한의 결정 가이드.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🔀'
+        title='서버/클라 fetch 6카드'
+        description='Server fetch · Client Query · Streaming · Revalidation · Optimistic · Mutation.'
+      >
+        <CardPlayground items={CARDS} />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/nextjs-routing/GoalViz.tsx
+++ b/src/components/playgrounds/nextjs-routing/GoalViz.tsx
@@ -1,0 +1,114 @@
+import { ReactNode } from 'react'
+
+export default function NextjsRoutingGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>폴더 이름이 곧 라우팅 문법.</p>
+      </header>
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🧩'
+          title='Dynamic Routes'
+          hook='[id] 폴더가 파라미터'
+        >
+          <p>
+            <code>[id]</code>는 한 세그먼트, <code>[...slug]</code>는 여러
+            세그먼트, <code>[[...optional]]</code>은 없을 수도.
+            <code>generateStaticParams</code>로 빌드 타임 정적 생성.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='2'
+          emoji='📁'
+          title='Route Groups'
+          hook='(folder) — URL 숨김'
+        >
+          <p>
+            <code>(marketing)</code>처럼 괄호로 감싼 폴더는 URL에 안 나타남.
+            서로 다른 layout을 적용하거나 파일 묶기 용도.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='3'
+          emoji='🔀'
+          title='Parallel Routes'
+          hook='@slot — 여러 영역 동시'
+        >
+          <p>
+            <code>@team</code>·<code>@analytics</code> 같은 슬롯이 layout의
+            prop으로 주입돼. 대시보드처럼 영역별 독립 로딩이 필요할 때.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='4'
+          emoji='🪟'
+          title='Intercepting'
+          hook='(..) — 경로 가로채기'
+        >
+          <p>
+            인스타처럼 썸네일 클릭 시 모달로 열리고 새로고침하면 전체 페이지로
+            열리는 UX를 한 트릭으로 구현.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='5'
+          emoji='🎨'
+          title='Loading·Error·NotFound UI'
+          hook='파일 이름만 맞추면 자동'
+        >
+          <p>
+            <code>loading.tsx</code>·<code>error.tsx</code>·
+            <code>not-found.tsx</code>는 약속된 파일명. 각 라우트 폴더 안에 두면
+            Suspense·ErrorBoundary로 자동 래핑.
+          </p>
+        </GoalCard>
+        <GoalCard
+          index='6'
+          emoji='🚦'
+          title='Middleware'
+          hook='라우트 도달 전 실행'
+        >
+          <p>
+            <code>middleware.ts</code>는 Edge 런타임에서 모든 요청 전 먼저 실행.
+            리다이렉트 · 헤더 추가 · i18n · 인증 가드에.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/nextjs-routing/index.tsx
+++ b/src/components/playgrounds/nextjs-routing/index.tsx
@@ -1,0 +1,197 @@
+import CardPlayground, {
+  type CardPlaygroundItem,
+} from '@/components/stages/CardPlayground'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+import GoalViz from './GoalViz'
+
+const CARDS: CardPlaygroundItem[] = [
+  {
+    id: 'dynamic',
+    emoji: '🧩',
+    title: 'Dynamic Routes',
+    subtitle: '[id] · [...slug] · [[...optional]]',
+    filename: 'app/posts/[id]/page.tsx',
+    code: `// app/posts/[id]/page.tsx
+type Props = { params: Promise<{ id: string }> }
+
+export default async function PostDetail({ params }: Props) {
+  const { id } = await params
+  const post = await db.post.findUnique({ where: { id: Number(id) } })
+  return <article>{post?.title}</article>
+}
+
+// 정적 생성 — 빌드 타임에 페이지 prerender
+export async function generateStaticParams() {
+  const posts = await db.post.findMany({ select: { id: true } })
+  return posts.map(p => ({ id: String(p.id) }))
+}`,
+    note: '[id]는 한 세그먼트, [...slug]는 여러 세그먼트, [[...optional]]은 세그먼트 없을 수도 있음. Next.js 15+에선 params가 Promise.',
+  },
+  {
+    id: 'route-groups',
+    emoji: '📁',
+    title: 'Route Groups (그룹화)',
+    subtitle: '(folder) — URL에 나오지 않는 논리 그룹',
+    filename: 'app 구조',
+    code: `app/
+  (marketing)/
+    layout.tsx       // 랜딩용 레이아웃
+    page.tsx         // /
+    about/page.tsx   // /about
+  (dashboard)/
+    layout.tsx       // 대시보드 레이아웃 (다른 chrome)
+    posts/page.tsx   // /posts
+    stats/page.tsx   // /stats
+
+// (marketing), (dashboard)는 URL에 안 나옴
+// 하지만 각기 다른 layout.tsx 적용 가능`,
+    lang: 'text',
+    note: '브랜치별로 레이아웃이 완전히 달라야 하거나, 파일을 논리적으로 묶고 싶지만 URL은 그대로 두고 싶을 때.',
+  },
+  {
+    id: 'parallel',
+    emoji: '🔀',
+    title: 'Parallel Routes (@slot)',
+    subtitle: '한 페이지에 여러 슬롯 동시 렌더',
+    filename: 'app/@modal',
+    code: `app/
+  layout.tsx         // 부모 layout이 slot들을 조합
+  page.tsx           // 메인 콘텐츠
+  @team/
+    page.tsx         // "팀 슬롯"
+  @analytics/
+    page.tsx         // "분석 슬롯"
+
+// layout.tsx
+export default function Layout({
+  children,
+  team,
+  analytics,
+}: {
+  children: React.ReactNode
+  team: React.ReactNode
+  analytics: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      <aside>{team}</aside>
+      <aside>{analytics}</aside>
+    </div>
+  )
+}`,
+    note: '대시보드처럼 여러 영역이 독립적으로 로딩·네비게이션되어야 할 때. 각 슬롯은 자체 loading.tsx · error.tsx를 가질 수 있어.',
+  },
+  {
+    id: 'intercepting',
+    emoji: '🪟',
+    title: 'Intercepting Routes (모달 패턴)',
+    subtitle: '(.)·(..)·(...)로 현재 경로를 "가로채기"',
+    filename: 'app/@modal/(..)photos',
+    code: `app/
+  feed/
+    page.tsx              // /feed
+    photos/[id]/page.tsx  // /feed/photos/3 — 전체 페이지
+  @modal/
+    (..)photos/[id]/
+      page.tsx            // /feed에서 클릭 → 모달로 표시
+
+// 동작:
+// /feed → 피드
+// 썸네일 클릭(soft nav) → URL은 /feed/photos/3 지만
+//   @modal 슬롯이 인터셉트해서 모달 오버레이
+// 새로고침 → 인터셉트 미적용, 전체 페이지로 열림 (Instagram 스타일)`,
+    note: '인스타그램의 &quot;이미지 클릭하면 모달, 새로고침하면 전체 페이지&quot; 패턴이 이거 한 트릭으로 구현됨.',
+  },
+  {
+    id: 'ui-conventions',
+    emoji: '🎨',
+    title: 'Loading · Error · Not Found UI',
+    subtitle: '파일 컨벤션 4가지',
+    filename: 'app/posts 디렉토리',
+    code: `app/posts/
+  page.tsx         // 정상 렌더
+  loading.tsx      // Suspense fallback — 자동 등록
+  error.tsx        // ErrorBoundary — 자동 등록 ('use client' 필요)
+  not-found.tsx    // notFound() 호출 시 표시
+  layout.tsx       // 중첩 레이아웃
+
+// loading.tsx 예시
+export default function Loading() {
+  return <Skeleton />
+}
+
+// error.tsx 예시
+'use client'
+export default function Error({ reset }: { reset: () => void }) {
+  return (
+    <div>
+      <p>문제가 발생했어요</p>
+      <button onClick={reset}>다시 시도</button>
+    </div>
+  )
+}`,
+    note: '파일 이름만 지키면 Suspense·ErrorBoundary가 자동으로 감싸져. 중첩도 자동 — /posts/[id]에 자체 loading.tsx를 두면 그 레벨만 대기.',
+  },
+  {
+    id: 'middleware',
+    emoji: '🚦',
+    title: 'Middleware',
+    subtitle: '요청이 라우트 진입 전에 실행',
+    filename: 'middleware.ts (프로젝트 루트)',
+    code: `// middleware.ts
+import { NextResponse, type NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('session')?.value
+
+  // 1) 미인증 사용자 리디렉트
+  if (!token && req.nextUrl.pathname.startsWith('/dashboard')) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  // 2) 응답 헤더 추가
+  const res = NextResponse.next()
+  res.headers.set('x-user-id', decode(token).userId)
+  return res
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/api/:path*'],  // 적용 경로
+}`,
+    note: '인증 가드 · i18n 라우팅 · A/B 테스트 · 봇 차단 등. Edge 런타임이라 빠르지만 Node API는 못 씀.',
+  },
+]
+
+export default function NextjsRoutingPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>App Router 라우팅 6가지 패턴</div>
+            <p className='mt-1 text-sm text-gray-700'>
+              Dynamic · Groups · Parallel · Intercepting ·
+              loading/error/not-found · Middleware — 카드로 한 장씩 넘기며
+              패턴을 훑자.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🗺️'
+        title='라우팅 패턴 6카드'
+        description='각 패턴의 폴더 구조와 코드 예시 · 주요 포인트.'
+      >
+        <CardPlayground items={CARDS} />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/react-19-actions/GoalViz.tsx
+++ b/src/components/playgrounds/react-19-actions/GoalViz.tsx
@@ -1,0 +1,149 @@
+import { ReactNode } from 'react'
+
+export default function React19ActionsGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          폼과 뮤테이션의 보일러플레이트가 3개 훅으로 녹아든다.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🕰️'
+          title='useActionState'
+          hook='action의 결과와 pending을 한 훅으로'
+        >
+          <p>
+            비동기 action 함수를 감싸면{' '}
+            <b>반환값(상태) · pending · invoke 함수</b> 세 가지를 돌려줘. form의{' '}
+            <code>action</code> prop에 직접 연결 가능.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const [state, action, isPending] = useActionState(
+  async (prev, formData) => {
+    const result = await save(formData)
+    return result   // 다음 prev가 됨
+  },
+  null              // 초기 state
+)
+
+<form action={action}>...</form>`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='📋'
+          title='useFormStatus'
+          hook='form 하위 컴포넌트에서 pending 관찰'
+        >
+          <p>
+            useActionState와 짝이 되는 훅. 부모 form이 대기 중이면 자식
+            SubmitButton이 자동으로 disable 될 수 있어.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`function Submit() {
+  const { pending } = useFormStatus()
+  return (
+    <button disabled={pending}>
+      {pending ? '저장 중...' : '저장'}
+    </button>
+  )
+}`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='⚡'
+          title='useOptimistic'
+          hook='UI를 미리 바꾸고 실패하면 롤백'
+        >
+          <p>
+            서버 응답이 오기 전에 UI를 &quot;응답이 성공했다 치고&quot; 미리
+            바꿔. 실패하면 React가 원본으로 되돌려.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`const [optimistic, add] = useOptimistic(
+  real,
+  (current, incoming) => [...current, incoming]
+)
+
+// 사용
+startTransition(() => {
+  add(newItem)     // UI 즉시 반영
+  serverAction()   // 뒤에서 서버 요청
+})`}
+          </pre>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🔗'
+          title='Server Actions와의 연결'
+          hook='폼 전송이 그대로 서버 함수 호출'
+        >
+          <p>
+            Next.js App Router에서는 <code>&quot;use server&quot;</code>{' '}
+            지시어로 서버 함수를 만들고 form의 <code>action</code>에 연결.
+            클라이언트에서 JS 번들링 안 되고 서버에서 바로 실행.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`// actions.ts
+'use server'
+export async function addPost(formData: FormData) {
+  await db.insert({ title: formData.get('title') })
+  revalidatePath('/posts')
+}
+
+// page.tsx
+<form action={addPost}>
+  <input name='title' />
+  <button>추가</button>
+</form>`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            JS 없이도 form이 동작하고 (progressive enhancement), JS 있으면
+            useOptimistic과 조합해 빠른 UX.
+          </p>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/react-19-actions/OptimisticLike.tsx
+++ b/src/components/playgrounds/react-19-actions/OptimisticLike.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { startTransition, useActionState, useOptimistic, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+type Post = { id: number; title: string; likes: number; liked: boolean }
+
+const INITIAL_POSTS: Post[] = [
+  { id: 1, title: 'React Quest 시작!', likes: 12, liked: false },
+  { id: 2, title: 'useMemo 정복기', likes: 34, liked: true },
+  { id: 3, title: 'Suspense + use 체험', likes: 7, liked: false },
+]
+
+// 서버를 흉내낸 mutation — 1초 지연 + 20% 실패
+async function toggleLikeOnServer(posts: Post[], id: number): Promise<Post[]> {
+  await new Promise((r) => setTimeout(r, 1000))
+  if (Math.random() < 0.2) throw new Error('network error')
+  return posts.map((p) =>
+    p.id === id
+      ? { ...p, liked: !p.liked, likes: p.liked ? p.likes - 1 : p.likes + 1 }
+      : p
+  )
+}
+
+export default function OptimisticLike() {
+  const [posts, setPosts] = useState<Post[]>(INITIAL_POSTS)
+
+  // useOptimistic: posts 배열에 &quot;낙관적 덮어쓰기&quot; 기능
+  const [optimisticPosts, addOptimistic] = useOptimistic(
+    posts,
+    (current: Post[], toggledId: number) =>
+      current.map((p) =>
+        p.id === toggledId
+          ? {
+              ...p,
+              liked: !p.liked,
+              likes: p.liked ? p.likes - 1 : p.likes + 1,
+            }
+          : p
+      )
+  )
+
+  // useActionState: action이 돌아간 뒤의 에러 메시지 담기
+  const [errorMessage, toggleAction, isPending] = useActionState<
+    string | null,
+    number
+  >(async (_prev, id) => {
+    try {
+      const updated = await toggleLikeOnServer(posts, id)
+      setPosts(updated)
+      return null
+    } catch (e) {
+      return e instanceof Error ? e.message : '알 수 없는 오류'
+    }
+  }, null)
+
+  const handleLike = (id: number) => {
+    startTransition(() => {
+      // 낙관적 UI 먼저 반영 (서버 응답 전)
+      addOptimistic(id)
+      // 그 다음에 action 실행
+      toggleAction(id)
+    })
+  }
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 좋아요 버튼을 눌러봐. 서버 응답은 1초 걸려.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            ⚡ <b>useOptimistic</b> — UI는 <b>즉시</b> 바뀜 (버튼 누르자마자 +1
+            또는 -1)
+          </li>
+          <li>
+            🕰️ <b>useActionState</b> — 서버 결과가 오면 공식값이 확정됨
+          </li>
+          <li>
+            ❌ <b>20% 확률로 실패</b> — 실패 시 낙관적 업데이트가 롤백되고 에러
+            메시지 표시
+          </li>
+        </ul>
+      </div>
+
+      {errorMessage && (
+        <div className='mb-3 rounded-lg bg-red-50 p-3 ring-1 ring-red-200'>
+          <div className='text-xs font-semibold tracking-wider text-red-800 uppercase'>
+            🚨 서버 에러
+          </div>
+          <div className='mt-1 font-mono text-sm text-red-900'>
+            {errorMessage} — 버튼을 다시 눌러 재시도
+          </div>
+        </div>
+      )}
+
+      <div className='mb-4 space-y-2'>
+        {optimisticPosts.map((p) => (
+          <div
+            key={p.id}
+            className='flex items-center justify-between rounded-xl bg-white p-4 ring-1 ring-gray-200'
+          >
+            <div>
+              <div className='text-xs font-semibold tracking-wider text-gray-500 uppercase'>
+                post #{p.id}
+              </div>
+              <div className='text-sm font-bold'>{p.title}</div>
+            </div>
+            <button
+              type='button'
+              onClick={() => handleLike(p.id)}
+              disabled={isPending}
+              className={cn(
+                'flex items-center gap-1.5 rounded-full border-2 px-4 py-2 text-sm font-bold transition',
+                p.liked
+                  ? 'border-[#ff5e48] bg-[#fff5f4] text-[#ff5e48]'
+                  : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48]',
+                isPending && 'opacity-60'
+              )}
+            >
+              <span>{p.liked ? '❤️' : '🤍'}</span>
+              <span className='font-mono'>{p.likes}</span>
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-3 text-xs text-gray-500 ring-1 ring-gray-100'>
+        isPending: <code>{isPending ? 'true' : 'false'}</code>
+        {' · '}공식 posts likes:{' '}
+        <code>{posts.map((p) => p.likes).join(', ')}</code>
+        {' · '}낙관적 likes:{' '}
+        <code>{optimisticPosts.map((p) => p.likes).join(', ')}</code>
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ setState + try/catch 수동',
+          code: `const [posts, setPosts] = useState(initial)
+const [pending, setPending] = useState(false)
+const [error, setError] = useState<string | null>(null)
+
+const like = async (id: number) => {
+  setPending(true)
+  const prev = posts
+  setPosts(posts.map(...))  // 낙관적
+  try {
+    const updated = await api.like(id)
+    setPosts(updated)
+  } catch (e) {
+    setPosts(prev)            // 롤백
+    setError(e.message)
+  } finally {
+    setPending(false)
+  }
+}`,
+          takeaway:
+            '낙관적 업데이트 + 롤백 + pending + 에러를 수동으로 관리. 보일러가 많음',
+        }}
+        after={{
+          label: '✅ React 19 Actions 3종',
+          code: `const [optimisticPosts, addOptimistic] = useOptimistic(
+  posts,
+  (current, id) => current.map(p => p.id === id ? { ...p, ... } : p)
+)
+
+const [error, likeAction, isPending] = useActionState(
+  async (_prev, id) => {
+    try {
+      const updated = await api.like(id)
+      setPosts(updated)
+      return null
+    } catch (e) { return e.message }
+  },
+  null
+)
+
+const handleLike = (id) => {
+  startTransition(() => {
+    addOptimistic(id)  // 즉시 UI 반영
+    likeAction(id)     // 서버 호출 + 결과 반영
+  })
+}`,
+          takeaway:
+            '낙관적·pending·에러가 각자의 훅으로 분리. 롤백은 React가 자동 (실패 시 원본 posts 그대로)',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 React 19 Actions 3종 세트
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            ⚡ <b>useOptimistic</b> — UI를 서버 응답 전에 미리 바꾸고, 응답 실패
+            시 자동 롤백
+          </li>
+          <li>
+            🕰️ <b>useActionState</b> — 비동기 action의 결과/에러와 isPending을
+            한 훅에
+          </li>
+          <li>
+            📋 <b>useFormStatus</b> — form 하위 컴포넌트에서 부모 form의 pending
+            상태를 읽음. Submit 버튼 disabling에 유용
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/react-19-actions/index.tsx
+++ b/src/components/playgrounds/react-19-actions/index.tsx
@@ -1,0 +1,37 @@
+import GoalViz from './GoalViz'
+import OptimisticLike from './OptimisticLike'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function React19ActionsPlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              좋아요 버튼 — 3종 훅이 협주하는 모습
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              서버 응답 1초 · 20% 실패 확률. 버튼 눌러서 낙관적 UI가 즉시
+              반응하고, 실패하면 자동 롤백되는 걸 확인해봐.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='❤️'
+        title='useOptimistic + useActionState'
+        description='실제 서버 없이 mock mutation. 낙관적 UI · pending · 실패 시 롤백 세 가지를 한 버튼에서 체험.'
+      >
+        <OptimisticLike />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/playgrounds/suspense-use/GoalViz.tsx
+++ b/src/components/playgrounds/suspense-use/GoalViz.tsx
@@ -1,0 +1,138 @@
+import { ReactNode } from 'react'
+
+export default function SuspenseUseGoalViz() {
+  return (
+    <section>
+      <header className='mb-4'>
+        <h3 className='text-lg font-extrabold'>🎯 학습 목표 — 풀어서 보기</h3>
+        <p className='text-sm text-gray-500'>
+          로딩 상태를 컴포넌트 밖으로 &quot;계단&quot;처럼 꺼내자.
+        </p>
+      </header>
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <GoalCard
+          index='1'
+          emoji='🪜'
+          title='Suspense boundary 설계'
+          hook='어디에 로딩을 붙일지가 UX'
+        >
+          <p>
+            boundary의 위치가 &quot;뭘 같이 기다릴지&quot;를 정해. 위쪽이면 큰
+            영역이 한 번에, 아래쪽이면 조각조각 따로.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`<Suspense fallback={<PageSkeleton />}>
+  <Suspense fallback={<HeaderSkeleton />}>
+    <Header />
+  </Suspense>
+  <Suspense fallback={<ListSkeleton />}>
+    <List />
+  </Suspense>
+</Suspense>`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            👉 놀이기구의 &quot;중첩 Suspense&quot; 토글로 둘을 비교.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='2'
+          emoji='🔓'
+          title='use hook으로 Promise 언래핑'
+          hook='"pending이면 Suspense에 throw" 를 약속한 훅'
+        >
+          <p>
+            React 19의 <code>use(promise)</code>는 Promise가 아직 안 풀렸으면
+            Suspense로 던지고, 풀렸으면 값을 반환해. useState+useEffect 왕복
+            없이 바로.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`function Posts({ promise }: { promise: Promise<Post[]> }) {
+  const posts = use(promise)  // pending → Suspense
+  return <List items={posts} />
+}`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            ⚠️ <code>use</code>는 조건부 호출 불가. &quot;훅 규칙&quot; 동일
+            적용.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='3'
+          emoji='🧯'
+          title='Suspense + Error Boundary 조합'
+          hook='로딩은 Suspense, 실패는 Error Boundary'
+        >
+          <p>
+            둘은 짝이야. <b>ErrorBoundary가 바깥, Suspense가 안쪽</b>이 일반적.
+          </p>
+          <pre className='mt-3 rounded-lg bg-gray-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-gray-700'>
+            {`<ErrorBoundary fallback={<ErrorView />}>
+  <Suspense fallback={<Loading />}>
+    <Posts />
+  </Suspense>
+</ErrorBoundary>`}
+          </pre>
+          <p className='mt-2 text-[12px] text-gray-500'>
+            성공: Posts · 로딩: Loading · 실패: ErrorView. 컴포넌트는 세
+            시나리오를 컴포지션으로 분리.
+          </p>
+        </GoalCard>
+
+        <GoalCard
+          index='4'
+          emoji='🌊'
+          title='Streaming SSR'
+          hook='HTML을 쪼개서 흘려보내기'
+        >
+          <p>
+            Next.js App Router에서 Suspense는 Streaming SSR의 핵심. 서버가
+            준비되는 부분부터 HTML을 흘려보내고, 나머지는 fallback로 자리잡은 뒤
+            나중에 교체.
+          </p>
+          <ul className='mt-2 space-y-1 text-[13px]'>
+            <li>🌊 첫 페인트(FCP)·LCP 개선</li>
+            <li>🌊 느린 부분이 빠른 부분을 막지 않음</li>
+            <li>
+              🌊 <code>loading.tsx</code>로 라우트 단위 fallback 자동 생성
+            </li>
+          </ul>
+        </GoalCard>
+      </div>
+    </section>
+  )
+}
+
+function GoalCard({
+  index,
+  emoji,
+  title,
+  hook,
+  children,
+}: {
+  index: string
+  emoji: string
+  title: string
+  hook: string
+  children: ReactNode
+}) {
+  return (
+    <article className='rounded-2xl border-2 border-gray-100 bg-white p-5'>
+      <header className='mb-3 flex items-start gap-3'>
+        <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-900 font-mono text-xs font-bold text-white'>
+          {index}
+        </span>
+        <div>
+          <h4 className='font-extrabold'>
+            <span className='mr-1'>{emoji}</span>
+            {title}
+          </h4>
+          <p className='mt-0.5 text-xs text-[#ff5e48]'>💡 {hook}</p>
+        </div>
+      </header>
+      <div className='space-y-2 text-sm text-gray-700'>{children}</div>
+    </article>
+  )
+}

--- a/src/components/playgrounds/suspense-use/SuspenseLab.tsx
+++ b/src/components/playgrounds/suspense-use/SuspenseLab.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { Suspense, use, useState } from 'react'
+import { cn } from '@/lib/cn'
+import BeforeAfter from '@/components/stages/BeforeAfter'
+
+// 가짜 fetch — delay 후 resolve 하는 Promise
+function makeDataPromise(label: string, delay: number): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(`✅ ${label} (${delay}ms)`), delay)
+  })
+}
+
+function DataCard({
+  promise,
+  label,
+}: {
+  promise: Promise<string>
+  label: string
+}) {
+  // React 19의 use hook — Promise가 pending이면 Suspense로 throw
+  const data = use(promise)
+  return (
+    <div className='rounded-xl bg-emerald-50 p-4 ring-1 ring-emerald-200'>
+      <div className='text-xs font-semibold tracking-wider text-emerald-800 uppercase'>
+        {label}
+      </div>
+      <div className='mt-1 font-mono text-sm font-bold text-emerald-900'>
+        {data}
+      </div>
+    </div>
+  )
+}
+
+function LoadingCard({ label, color }: { label: string; color: string }) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-xl p-4 ring-1',
+        color === 'red' ? 'bg-red-50 ring-red-200' : 'bg-sky-50 ring-sky-200'
+      )}
+    >
+      <div
+        className={cn(
+          'text-xs font-semibold tracking-wider uppercase',
+          color === 'red' ? 'text-red-800' : 'text-sky-800'
+        )}
+      >
+        {label}
+      </div>
+      <div className='mt-1 font-mono text-sm'>⏳ 불러오는 중...</div>
+    </div>
+  )
+}
+
+export default function SuspenseLab() {
+  const [runKey, setRunKey] = useState(0)
+  const [nested, setNested] = useState(true)
+
+  // 버튼을 누를 때마다 새 Promise 생성 (runKey로 key 변경해 Suspense 재진입)
+  const fastPromise = makeDataPromise('빠른 데이터', 400)
+  const slowPromise = makeDataPromise('느린 데이터', 1800)
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setRunKey((k) => k + 1)}
+          className='rounded-full bg-[#ff5e48] px-4 py-2 text-sm font-bold text-white hover:bg-[#ec4b36]'
+        >
+          🚀 다시 불러오기 (run #{runKey})
+        </button>
+        <button
+          type='button'
+          onClick={() => setNested((v) => !v)}
+          className={cn(
+            'rounded-full px-4 py-2 text-sm font-bold transition',
+            nested
+              ? 'bg-emerald-500 text-white'
+              : 'border border-gray-300 bg-white text-gray-700'
+          )}
+        >
+          {nested ? '🪆 중첩 Suspense 켜짐' : '⬜️ 하나의 Suspense'}
+        </button>
+      </div>
+
+      <div className='mb-3 rounded-lg bg-white p-4 text-sm text-gray-700 ring-1 ring-gray-100'>
+        <p>
+          🎯 <b>관찰 포인트</b>: 두 Promise(400ms · 1800ms)가 각자 결과를
+          기다려.
+        </p>
+        <ul className='mt-2 space-y-1'>
+          <li>
+            🪆 <b>중첩 Suspense</b>: 각 카드가 자기 Suspense로 감싸져 있어 빠른
+            것은 빨리, 느린 것은 따로. 사용자가 덜 기다리는 체감.
+          </li>
+          <li>
+            ⬜ <b>하나의 Suspense</b>: 둘을 같은 boundary 안에 묶어놓으면{' '}
+            <b>둘 다 완료될 때까지</b> fallback. 느린 쪽 기준으로 지연.
+          </li>
+        </ul>
+      </div>
+
+      <div className='mb-4' key={runKey}>
+        {nested ? (
+          <div className='grid gap-3 md:grid-cols-2'>
+            <Suspense
+              fallback={<LoadingCard label='빠른 데이터' color='sky' />}
+            >
+              <DataCard promise={fastPromise} label='🏃 빠른 데이터' />
+            </Suspense>
+            <Suspense
+              fallback={<LoadingCard label='느린 데이터' color='red' />}
+            >
+              <DataCard promise={slowPromise} label='🐢 느린 데이터' />
+            </Suspense>
+          </div>
+        ) : (
+          <Suspense
+            fallback={
+              <div className='grid gap-3 md:grid-cols-2'>
+                <LoadingCard label='둘 다 기다리는 중' color='sky' />
+                <LoadingCard label='둘 다 기다리는 중' color='red' />
+              </div>
+            }
+          >
+            <div className='grid gap-3 md:grid-cols-2'>
+              <DataCard promise={fastPromise} label='🏃 빠른 데이터' />
+              <DataCard promise={slowPromise} label='🐢 느린 데이터' />
+            </div>
+          </Suspense>
+        )}
+      </div>
+
+      <BeforeAfter
+        before={{
+          label: '❌ useState + useEffect 로딩 처리',
+          code: `function Posts() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchPosts().then(d => {
+      setData(d)
+      setLoading(false)
+    })
+  }, [])
+
+  if (loading) return <Spinner />
+  return <List items={data} />
+}`,
+          takeaway:
+            '각 컴포넌트가 자체 loading state를 관리. 중첩되면 코드가 산만해짐',
+        }}
+        after={{
+          label: '✅ Suspense + use',
+          code: `function Posts() {
+  // use: Promise가 pending이면 Suspense로 throw
+  const posts = use(fetchPosts())
+  return <List items={posts} />
+}
+
+<Suspense fallback={<Spinner />}>
+  <Posts />
+</Suspense>`,
+          takeaway:
+            '로딩 UI는 boundary로 중앙집중화. 컴포넌트는 "성공했을 때만" 생각',
+        }}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 Suspense 디자인 원칙
+        </div>
+        <ul className='space-y-1 text-gray-700'>
+          <li>
+            🎯 <b>boundary를 어디에 두느냐가 UX</b>. 위로 갈수록 큰 영역이 한
+            번에 대기, 아래로 내려갈수록 부분적 스켈레톤.
+          </li>
+          <li>
+            🎯 <b>Error Boundary를 바깥</b>에 — Suspense는 로딩, ErrorBoundary는
+            실패를 담당. 서로 감싸는 관계가 자연스러움.
+          </li>
+          <li>
+            🎯 <code>use</code>는 <b>조건부 호출 불가</b>. 훅 규칙과 동일.
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/playgrounds/suspense-use/index.tsx
+++ b/src/components/playgrounds/suspense-use/index.tsx
@@ -1,0 +1,37 @@
+import GoalViz from './GoalViz'
+import SuspenseLab from './SuspenseLab'
+import PlaygroundSection from '@/components/stages/PlaygroundSection'
+
+export default function SuspenseUsePlayground() {
+  return (
+    <div className='flex flex-col gap-12'>
+      <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] p-5'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>🎮</span>
+          <div>
+            <div className='font-extrabold'>
+              로딩을 &quot;컴포넌트가 아니라 경계&quot;에서
+            </div>
+            <p className='mt-1 text-sm text-gray-700'>
+              두 Promise가 각자 속도로 풀려. 중첩 Suspense 토글을 눌러가며
+              스켈레톤이 조각조각 교체되는지, 한꺼번에 나타나는지를 비교해봐.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <GoalViz />
+
+      <div className='border-t border-gray-200' />
+
+      <PlaygroundSection
+        index='A'
+        emoji='🪜'
+        title='Suspense 중첩 vs 하나의 boundary'
+        description='React 19 use hook + 두 속도의 Promise. 같은 데이터를 중첩 Suspense로 조각내 보여줄 때와 한 boundary로 묶을 때 UX 차이를 몸으로.'
+      >
+        <SuspenseLab />
+      </PlaygroundSection>
+    </div>
+  )
+}

--- a/src/components/stages/CardPlayground.tsx
+++ b/src/components/stages/CardPlayground.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+import CodeBlock from './CodeBlock'
+
+export type CardPlaygroundItem = {
+  id: string
+  emoji: string
+  title: string
+  subtitle?: string
+  tagline?: string
+  code: string
+  filename?: string
+  lang?: string
+  note: string
+  pros?: string[]
+  cons?: string[]
+}
+
+type Props = {
+  items: CardPlaygroundItem[]
+}
+
+export default function CardPlayground({ items }: Props) {
+  const [activeId, setActiveId] = useState(items[0]?.id)
+  const current = items.find((c) => c.id === activeId) ?? items[0]
+  if (!current) return null
+
+  return (
+    <div className='rounded-2xl border-2 border-gray-200 bg-gray-50/70 p-5'>
+      <div className='mb-4 flex flex-wrap gap-2'>
+        {items.map((c) => (
+          <button
+            key={c.id}
+            type='button'
+            onClick={() => setActiveId(c.id)}
+            className={cn(
+              'rounded-full border-2 px-3 py-1.5 text-xs font-bold transition',
+              activeId === c.id
+                ? 'border-[#ff5e48] bg-[#ff5e48] text-white'
+                : 'border-gray-200 bg-white text-gray-700 hover:border-[#ff5e48]'
+            )}
+          >
+            {c.emoji} {c.title}
+          </button>
+        ))}
+      </div>
+
+      <div className='mb-3 rounded-xl bg-white p-4 ring-1 ring-gray-100'>
+        <div className='flex items-start gap-3'>
+          <span className='text-3xl'>{current.emoji}</span>
+          <div>
+            <h4 className='font-extrabold'>{current.title}</h4>
+            {current.subtitle && (
+              <p className='text-sm text-gray-600'>{current.subtitle}</p>
+            )}
+            {current.tagline && (
+              <span className='mt-2 inline-block rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-bold text-amber-900'>
+                {current.tagline}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <CodeBlock
+        filename={current.filename ?? `${current.title}.tsx`}
+        code={current.code}
+        lang={current.lang ?? 'tsx'}
+      />
+
+      <div className='mt-4 rounded-xl border-2 border-gray-100 bg-white p-4 text-sm'>
+        <div className='mb-2 text-xs font-bold tracking-wider text-gray-500 uppercase'>
+          💭 포인트
+        </div>
+        <p className='text-gray-700'>{current.note}</p>
+      </div>
+
+      {(current.pros || current.cons) && (
+        <div className='mt-3 grid gap-3 md:grid-cols-2'>
+          {current.pros && (
+            <div className='rounded-xl bg-emerald-50 p-4 ring-1 ring-emerald-200'>
+              <div className='text-xs font-bold tracking-wider text-emerald-800 uppercase'>
+                👍 장점
+              </div>
+              <ul className='mt-2 space-y-1 text-sm text-emerald-900'>
+                {current.pros.map((p) => (
+                  <li key={p}>{p}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {current.cons && (
+            <div className='rounded-xl bg-amber-50 p-4 ring-1 ring-amber-200'>
+              <div className='text-xs font-bold tracking-wider text-amber-800 uppercase'>
+                ⚠️ 주의
+              </div>
+              <ul className='mt-2 space-y-1 text-sm text-amber-900'>
+                {current.cons.map((c) => (
+                  <li key={c}>{c}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/data/playgrounds.ts
+++ b/src/data/playgrounds.ts
@@ -15,6 +15,12 @@ import UseContextPlayground from '@/components/playgrounds/usecontext'
 import UseReducerPlayground from '@/components/playgrounds/usereducer'
 import TanStackQueryPlayground from '@/components/playgrounds/tanstack-query'
 import StateLibsPlayground from '@/components/playgrounds/state-libs'
+import SuspenseUsePlayground from '@/components/playgrounds/suspense-use'
+import React19ActionsPlayground from '@/components/playgrounds/react-19-actions'
+import AppRouterPlayground from '@/components/playgrounds/app-router'
+import NextjsRoutingPlayground from '@/components/playgrounds/nextjs-routing'
+import DataFetchingPlayground from '@/components/playgrounds/data-fetching'
+import AuthPatternsPlayground from '@/components/playgrounds/auth-patterns'
 
 export const playgrounds: Record<string, ComponentType> = {
   // 🎣 훅
@@ -36,6 +42,13 @@ export const playgrounds: Record<string, ComponentType> = {
   'stage-10-usereducer': UseReducerPlayground,
   'stage-tanstack-query': TanStackQueryPlayground,
   'stage-state-libs': StateLibsPlayground,
+  // 🌊 API
+  'stage-suspense-use': SuspenseUsePlayground,
+  'stage-react-19-actions': React19ActionsPlayground,
+  'bonus-app-router': AppRouterPlayground,
+  'stage-nextjs-routing': NextjsRoutingPlayground,
+  'stage-data-fetching': DataFetchingPlayground,
+  'stage-auth-patterns': AuthPatternsPlayground,
 }
 
 export const hasPlayground = (stageId: string): boolean =>


### PR DESCRIPTION
closes #23

🌊 API 탭 **6/6** 플레이 가능 달성. 인터랙티브 2 + 카드형 4.

## 신규 공통 컴포넌트
- **CardPlayground** — 탭 카드 네비 + CodeBlock + note + 선택적 pros/cons. 배치 5의 4개 스테이지에서 재사용, 앞으로 인프라 탭에서도 활용 예정

## 스테이지 (6)

- **Suspense + use** — SuspenseLab (React 19 use hook + 중첩/단일 Suspense 토글)
- **React 19 Actions** — OptimisticLike (useOptimistic + useActionState + startTransition 좋아요)
- **Next.js App Router** — 4카드 (RSC vs Client · 경계 · Server Actions · 캐싱)
- **Next.js 라우팅 마스터** — 6카드 (Dynamic · Groups · Parallel · Intercepting · loading/error UI · Middleware)
- **Server vs Client Fetching** — 6카드 (Server fetch · Client Query · Streaming · Revalidation · Optimistic · Mutation)
- **Auth 패턴** — 5카드 (Auth.js v5 셋업 · JWT vs Session · Middleware · OAuth · RBAC)

## 전체 현황 (22/28)

- 🎣 훅: 6/6 ✅
- ⚡ 성능 ⭐: 6/6 ✅
- 🗂 상태 관리: 4/4 ✅
- 🌊 API: **6/6** ✅
- 🛠 인프라: 0/6 ← 마지막 배치

## 다음

Batch 6 (최종) — 🛠 인프라 탭 6개 (a11y · 테스트 · RHF+Zod · Framer Motion · 에러 아키텍처 · 디자인 시스템)
