### PR TITLE
♻️ Refactor: 렌더링 기초 — 김민지 페르소나 보이스 적용

### DIFF
--- a/src/components/playgrounds/rendering/BasicPlay.tsx
+++ b/src/components/playgrounds/rendering/BasicPlay.tsx
@@ -6,18 +6,18 @@ type ChildProps = { id: string }
 
 function Child({ id }: ChildProps) {
   const renders = useRef(0)
+  // 교육용 렌더 카운터 — 의도적으로 렌더 중 ref 조작
   // eslint-disable-next-line react-hooks/refs
   renders.current += 1
+  // eslint-disable-next-line react-hooks/refs
+  const count = renders.current
   return (
     <div className='flex flex-col items-center gap-1 rounded-2xl bg-white p-5 text-center ring-1 ring-gray-200'>
       <span className='text-3xl'>{id}</span>
       <span className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
         내가 그려진 횟수
       </span>
-      {/* eslint-disable-next-line react-hooks/refs */}
-      <span className='font-mono text-3xl font-extrabold'>
-        {renders.current}
-      </span>
+      <span className='font-mono text-3xl font-extrabold'>{count}</span>
     </div>
   )
 }

--- a/src/components/playgrounds/rendering/DeepenPlay.tsx
+++ b/src/components/playgrounds/rendering/DeepenPlay.tsx
@@ -7,18 +7,18 @@ type ChildProps = { id: string }
 
 function ChildInner({ id }: ChildProps) {
   const renders = useRef(0)
+  // 교육용 렌더 카운터 — 의도적으로 렌더 중 ref 조작
   // eslint-disable-next-line react-hooks/refs
   renders.current += 1
+  // eslint-disable-next-line react-hooks/refs
+  const count = renders.current
   return (
     <div className='flex flex-col items-center gap-1 rounded-2xl bg-white p-5 text-center ring-1 ring-gray-200'>
       <span className='text-3xl'>{id}</span>
       <span className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
         내가 그려진 횟수
       </span>
-      {/* eslint-disable-next-line react-hooks/refs */}
-      <span className='font-mono text-3xl font-extrabold'>
-        {renders.current}
-      </span>
+      <span className='font-mono text-3xl font-extrabold'>{count}</span>
     </div>
   )
 }

--- a/src/components/playgrounds/rendering/index.tsx
+++ b/src/components/playgrounds/rendering/index.tsx
@@ -1,105 +1,50 @@
 import BasicPlay from './BasicPlay'
 import DeepenPlay from './DeepenPlay'
-import CodeBlock from '@/components/stages/CodeBlock'
 import StageFlow from '@/components/stages/StageFlow'
 
 export default function RenderingPlayground() {
   return (
     <StageFlow>
-      <StageFlow.Why subtitle='3줄 요약'>
-        <ul className='space-y-1.5'>
-          <li>
-            🖼️ React는 state가 바뀌면 화면을 <b>다시 그려</b> (리렌더).
-          </li>
-          <li>
-            🔁 한 번 바뀌면 어디까지 다시 그려지는지{' '}
-            <b>감이 없으면 최적화가 불가능</b>해.
-          </li>
-          <li>
-            🎯 이걸 눈으로 익히면 <b>useMemo · useCallback · React.memo</b>가 왜
-            필요한지 자연스럽게 이해돼.
-          </li>
-        </ul>
-      </StageFlow.Why>
+      <StageFlow.Empathy>
+        🙋 &quot;버튼 하나 눌렀을 뿐인데 왜 다른 애들도 움직이지?&quot; — 나도
+        처음엔 당황했거든.
+      </StageFlow.Empathy>
 
-      <StageFlow.Play subtitle='지금 바로 눌러보고, 설명은 그 다음'>
+      <StageFlow.Play subtitle='버튼 눌러봐. 숫자 3개가 뭘 하는지만 봐'>
         <BasicPlay />
       </StageFlow.Play>
 
-      <StageFlow.Explain subtitle='3줄 해설'>
-        <ul className='space-y-1.5'>
-          <li>
-            ⚡ <b>부모가 리렌더되면 자식도 함께 리렌더</b>돼. 자식 props가 안
-            바뀌었어도 그래.
-          </li>
-          <li>
-            🧬 자식 함수가 다시 실행돼서 카운트가 올라가는 것 — 이게{' '}
-            <b>React의 기본 동작</b>이야.
-          </li>
-          <li>
-            🐌 대부분 빨라서 문제 없음. 근데 자식이 무겁거나 많으면 체감이
-            시작돼.
-          </li>
-        </ul>
-      </StageFlow.Explain>
+      <StageFlow.Observe
+        title='🤔 어? 내가 안 건드린 🟢🔵🟠도 숫자가 올랐네?'
+        subtitle='왜 그랬을까?'
+      >
+        <p>
+          부모가 &quot;다시 그리기&quot; (= 리렌더) 되면 자식 세 명도 덩달아
+          다시 그려져. 리액트는 원래 이렇게 움직여 — 자식 &quot;부모가 준
+          값&quot; (= props)이 안 바뀌었어도 그래.
+        </p>
+      </StageFlow.Observe>
 
       <StageFlow.Deepen
-        title='🔬 자식에게 방패를 씌워보자 — React.memo'
-        subtitle='토글 껐다 켰다 하며 카운트 비교'
+        title='🛡️ 자식에게 방패 씌우고 다시 눌러봐'
+        subtitle='이번엔 토글 ON'
       >
         <DeepenPlay />
+        <p className='mt-3 text-[13px] text-gray-700'>
+          🔍 방패 켜면 자식이 &quot;나 props 그대로인데 굳이 다시 그려?&quot;
+          하고 건너뛰어. 이게 <code>React.memo</code>가 하는 일이야.
+        </p>
       </StageFlow.Deepen>
 
-      <StageFlow.Code subtitle='방패 없이 vs 있이'>
-        <div className='grid gap-3 md:grid-cols-2'>
-          <div>
-            <div className='mb-2 inline-block rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-bold text-red-800'>
-              🚫 방패 없음 — 부모 따라 리렌더
-            </div>
-            <CodeBlock
-              filename='Child.tsx'
-              code={`function Child({ label }: { label: string }) {
-  return <div>{label}</div>
-}`}
-            />
-          </div>
-          <div>
-            <div className='mb-2 inline-block rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-800'>
-              ✅ 방패 있음 — props 같으면 스킵
-            </div>
-            <CodeBlock
-              filename='Child.tsx'
-              code={`const Child = memo(function Child({ label }) {
-  return <div>{label}</div>
-})`}
-            />
-          </div>
-        </div>
-        <p className='mt-3 rounded-lg bg-gray-50 p-3 text-[12px] text-gray-600'>
-          💡 <b>참고</b>: 가벼운 자식엔 방패가 오히려 낭비야. 진짜 비싼 자식에만
-          씌우는 게 요령.
+      <StageFlow.Next subtitle='한 줄 정리 + 다음'>
+        <p className='mb-2'>
+          ✔️ <b>부모가 그려지면 자식도 같이 그려진다</b> — 이게 기본.
         </p>
-      </StageFlow.Code>
-
-      <StageFlow.Wrap>
-        <ul className='space-y-1.5'>
-          <li>
-            ✔️ 리렌더는 <b>부모 → 자식으로 전염</b>된다.
-          </li>
-          <li>
-            ✔️ 기본은 빠름. 문제 생길 때만 <b>React.memo</b>로 자식을 지켜줘.
-          </li>
-          <li>
-            ✔️ 다음 스테이지에선 메모이제이션 3종 (useMemo · useCallback ·
-            memo)을 본격적으로 만져볼 거야.
-          </li>
-        </ul>
-        <p className='mt-3 rounded-lg bg-white p-3 text-xs ring-1 ring-gray-200'>
-          👉 위 세 줄이 자연스럽게 이해됐다면 <b>&quot;✅ 정복했어!&quot;</b>{' '}
-          버튼을 눌러도 좋아. 아직 얼떨떨하면{' '}
-          <b>Play/Deepen 버튼을 한 번씩 더</b> 눌러봐.
+        <p className='text-gray-700'>
+          다음은 &quot;정말 비싼 계산&quot;을 기억해두기(= 메모이제이션)로
+          건너뛰는 <b>useMemo</b> 차례야 🚀
         </p>
-      </StageFlow.Wrap>
+      </StageFlow.Next>
     </StageFlow>
   )
 }

--- a/src/components/stages/StageFlow.tsx
+++ b/src/components/stages/StageFlow.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from 'react'
 import { cn } from '@/lib/cn'
 
-type SectionKind = 'why' | 'play' | 'explain' | 'deepen' | 'code' | 'wrap'
+type SectionKind = 'play' | 'observe' | 'deepen' | 'next'
 
 type SectionProps = {
-  step: string
+  step?: string
   kind: SectionKind
   title: string
   subtitle?: string
@@ -15,17 +15,12 @@ const KIND_STYLES: Record<
   SectionKind,
   { border: string; badge: string; bg: string }
 > = {
-  why: {
-    border: 'border-amber-300',
-    badge: 'bg-amber-400 text-amber-950',
-    bg: 'bg-amber-50/60',
-  },
   play: {
     border: 'border-[#ff5e48]',
     badge: 'bg-[#ff5e48] text-white',
     bg: 'bg-[#fff5f4]',
   },
-  explain: {
+  observe: {
     border: 'border-emerald-300',
     badge: 'bg-emerald-500 text-white',
     bg: 'bg-emerald-50/60',
@@ -35,13 +30,8 @@ const KIND_STYLES: Record<
     badge: 'bg-violet-500 text-white',
     bg: 'bg-violet-50/60',
   },
-  code: {
-    border: 'border-gray-300',
-    badge: 'bg-gray-800 text-white',
-    bg: 'bg-white',
-  },
-  wrap: {
-    border: 'border-[#ff5e48]',
+  next: {
+    border: 'border-amber-300',
     badge: 'bg-gray-900 text-white',
     bg: 'bg-[#fff8ec]',
   },
@@ -52,14 +42,16 @@ function Section({ step, kind, title, subtitle, children }: SectionProps) {
   return (
     <section className={cn('rounded-2xl border-l-4 px-6 py-5', s.border, s.bg)}>
       <header className='mb-3 flex items-center gap-3'>
-        <span
-          className={cn(
-            'flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-mono text-sm font-black shadow-sm',
-            s.badge
-          )}
-        >
-          {step}
-        </span>
+        {step && (
+          <span
+            className={cn(
+              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-mono text-sm font-black shadow-sm',
+              s.badge
+            )}
+          >
+            {step}
+          </span>
+        )}
         <div>
           <h3 className='text-lg leading-tight font-extrabold'>{title}</h3>
           {subtitle && (
@@ -73,89 +65,76 @@ function Section({ step, kind, title, subtitle, children }: SectionProps) {
 }
 
 function Root({ children }: { children: ReactNode }) {
-  return <div className='flex flex-col gap-6'>{children}</div>
+  return <div className='flex flex-col gap-4'>{children}</div>
 }
 
-// 각 단계 전용 컴포넌트 — 기본 title/kind 지정, 호출자는 title 재지정 가능
-function Why({
-  title = '🎯 왜 배우면 좋을까?',
-  subtitle,
-  children,
-}: Partial<SectionProps>) {
+// 공감 한 줄 — 인트로 바 (섹션 번호 없음)
+function Empathy({ children }: { children: ReactNode }) {
   return (
-    <Section step='①' kind='why' title={title!} subtitle={subtitle}>
-      {children}
-    </Section>
+    <div className='rounded-2xl bg-linear-to-br from-[#fff5f4] to-[#ffe8e3] px-6 py-4'>
+      <p className='text-base font-bold text-gray-800'>{children}</p>
+    </div>
   )
 }
 
+// ① 실습
 function Play({
   title = '🎮 일단 눌러봐',
-  subtitle = '이론 먼저 읽지 말고',
-  children,
-}: Partial<SectionProps>) {
-  return (
-    <Section step='②' kind='play' title={title!} subtitle={subtitle}>
-      {children}
-    </Section>
-  )
-}
-
-function Explain({
-  title = '💡 방금 뭐가 일어난 거야?',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='③' kind='explain' title={title!} subtitle={subtitle}>
+    <Section step='①' kind='play' title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )
 }
 
+// ② 관찰 질문 + 해설 2문장
+function Observe({
+  title = '🤔 어? 이거 뭐지?',
+  subtitle,
+  children,
+}: Partial<SectionProps>) {
+  return (
+    <Section step='②' kind='observe' title={title!} subtitle={subtitle}>
+      {children}
+    </Section>
+  )
+}
+
+// ③ 한 단계 더 실험
 function Deepen({
-  title = '🔬 한 단계 더 실험',
+  title = '🔬 한 번 더, 이번엔 조건을 바꿔봐',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='④' kind='deepen' title={title!} subtitle={subtitle}>
+    <Section step='③' kind='deepen' title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )
 }
 
-function Code({
-  title = '📚 코드로 확인',
+// ④ 다음
+function Next({
+  title = '🚀 다음으로',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='⑤' kind='code' title={title!} subtitle={subtitle}>
-      {children}
-    </Section>
-  )
-}
-
-function Wrap({
-  title = '✅ 정리 — 이제 정복 버튼 눌러도 돼',
-  subtitle,
-  children,
-}: Partial<SectionProps>) {
-  return (
-    <Section step='⑥' kind='wrap' title={title!} subtitle={subtitle}>
+    <Section step='④' kind='next' title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )
 }
 
 const StageFlow = Object.assign(Root, {
-  Why,
+  Empathy,
   Play,
-  Explain,
+  Observe,
   Deepen,
-  Code,
-  Wrap,
+  Next,
 })
 
 export default StageFlow


### PR DESCRIPTION
## 왜 바꿨나

사용자가 상세 브리프 제공:
- 페르소나: 김민지 (비전공자 3개월차, 퇴근 후 20분, "나만 이해 못 하나")
- 목표: 한 글에 "아 그거구나!" 1회
- 구조: 공감 1문장 → 실습 → 관찰 질문 → 해설 2문장 → 다음
- 분량: 스크롤 3번, 섹션 4개 이하, 한 섹션 3문장 이하
- 톤: "~야/~거든", "~입니다" 금지
- 용어 글로서리: 렌더링→다시 그리기, props→부모가 준 값 등

## 변경 사항

**StageFlow 템플릿**
- 기존 6단 구조(Why/Play/Explain/Deepen/Code/Wrap) → **5단(Empathy/Play/Observe/Deepen/Next)**로 교체
- Empathy는 인트로 바(번호 없음), 나머지 ①~④
- 각 섹션 컬러 + 번호 뱃지로 플로우 시각화

**렌더링 기초 (STAGE 1)**
- 공감: "버튼 하나 눌렀을 뿐인데 왜 다른 애들도 움직이지? — 나도 처음엔 당황했거든"
- 실습: 단일 버튼 + 자식 3개 (BasicPlay)
- 관찰+해설: "어? 내가 안 건드린 🟢🔵🟠도 숫자가 올랐네?" + 해설 2문장
- 심화: 방패(React.memo) 토글 + 1문장 해설
- 다음: 1줄 정리 + useMemo 유도

## 메모리에 저장

`feedback_beginner_language.md`를 페르소나·구조·글로서리·체크리스트까지 상세 업데이트 → 앞으로 작성하는 모든 스테이지에 자동 적용 예정.

## 확인
http://localhost:3000/stages/stage-1-rendering

피드백 받고 나머지 27개 일괄 적용(PR 별도).
