### PR TITLE
🎨 Style: 포트폴리오 디자인 시스템 이식 + 전면 리디자인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "motion": "^12.38.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4434,6 +4435,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6074,6 +6102,47 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "motion": "^12.38.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,11 @@
 import Dashboard from '@/components/quest/Dashboard'
-import Legend from '@/components/quest/Legend'
 import QuestTabs from '@/components/quest/QuestTabs'
 import AchievementGrid from '@/components/quest/Achievement'
+import FadeIn from '@/components/ui/FadeIn'
+import Section from '@/components/ui/Section'
+import SectionHeader from '@/components/ui/SectionHeader'
+import Badge from '@/components/ui/Badge'
+import Text from '@/components/ui/Text'
 import { isCategoryId } from '@/data/stages'
 
 type HomeProps = {
@@ -13,31 +17,60 @@ export default async function Home({ searchParams }: HomeProps) {
   const initialTab = isCategoryId(tab) ? tab : 'hooks'
 
   return (
-    <div className='mx-auto max-w-240 px-6 py-12'>
-      <section className='mb-14 text-center'>
-        <div className='animate-quest-bounce mb-4 text-7xl'>🎮</div>
-        <h1 className='mb-3 text-5xl font-black tracking-[-0.02em] sm:text-[56px]'>
-          React <span className='text-[#ff5e48]'>Playground</span>
-        </h1>
-        <p className='text-lg text-gray-500'>
-          훅을 눌러보고, 망가뜨리고, 체화하는 놀이터
-        </p>
-      </section>
+    <>
+      {/* Hero */}
+      <Section padding='lg'>
+        <FadeIn>
+          <div className='flex flex-col items-center text-center'>
+            <Badge label='🎮 React Quest' theme='orange' size='md' />
+            <Text as='display' className='mt-6 break-keep whitespace-pre-line'>
+              {`훅을 눌러보고\n망가뜨리며 체화하는 `}
+              <span className='text-orange-500'>놀이터</span>
+            </Text>
+            <Text as='body' className='mt-6 max-w-xl text-gray-500'>
+              이론 먼저 외우지 말고 버튼부터 눌러봐. 28개 스테이지, 모두 직접
+              만져보면서 감 잡는 구성이야.
+            </Text>
+          </div>
+        </FadeIn>
+      </Section>
 
-      <Dashboard />
-      <Legend />
+      {/* Dashboard */}
+      <Section padding='sm'>
+        <FadeIn delay={0.1}>
+          <Dashboard />
+        </FadeIn>
+      </Section>
 
-      <QuestTabs initialTab={initialTab} />
+      {/* Tabs */}
+      <Section padding='md'>
+        <FadeIn delay={0.1}>
+          <SectionHeader
+            badge='🗺 로드맵'
+            title='어디서부터 시작해볼까?'
+            description='5개 탭 · 28개 스테이지 · 클리어하면 뱃지 자동 해금'
+          />
+        </FadeIn>
+        <div className='mt-10'>
+          <QuestTabs initialTab={initialTab} />
+        </div>
+      </Section>
 
-      <section className='mb-12'>
-        <header className='mb-6 border-b-2 border-gray-100 pb-4'>
-          <h2 className='mb-1 text-2xl font-extrabold'>🏆 획득 뱃지</h2>
-          <p className='text-sm text-gray-500'>
-            스테이지를 깨면 자동으로 해금됩니다
-          </p>
-        </header>
-        <AchievementGrid />
-      </section>
-    </div>
+      {/* Achievements */}
+      <Section padding='lg' className='bg-white'>
+        <FadeIn>
+          <SectionHeader
+            badge='🏆 뱃지'
+            title='오늘 어디까지 왔어?'
+            description='스테이지를 정복할 때마다 자동으로 해금돼'
+          />
+        </FadeIn>
+        <div className='mt-10'>
+          <FadeIn delay={0.1}>
+            <AchievementGrid />
+          </FadeIn>
+        </div>
+      </Section>
+    </>
   )
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,3 +1,5 @@
+import Text from '@/components/ui/Text'
+
 const links = [
   { href: 'https://narae-ux-portfolio.vercel.app', label: '🎨 UX 포트폴리오' },
   { href: 'https://jerryko570.github.io', label: "📝 Jerry's blog" },
@@ -9,20 +11,22 @@ const links = [
 
 export default function Footer() {
   return (
-    <footer className='mt-14 bg-gradient-to-br from-[#fff8ec] to-[#fef0e8]'>
-      <div className='mx-auto max-w-240 px-6 py-10 text-center'>
-        <h3 className='mb-2 text-lg font-extrabold'>🔗 연결된 자산들</h3>
-        <p className='mb-5 text-sm text-gray-500'>
+    <footer className='mt-16 bg-linear-to-br from-[#fff8ec] to-[#fef0e8]'>
+      <div className='mx-auto max-w-6xl px-6 py-16 text-center sm:px-8'>
+        <Text as='h5' className='font-extrabold'>
+          🔗 연결된 자산들
+        </Text>
+        <Text as='p' className='mx-auto mt-3 max-w-md text-gray-500'>
           React Quest는 다른 프로젝트들과 이어져 있어요
-        </p>
-        <div className='flex flex-wrap justify-center gap-3'>
+        </Text>
+        <div className='mt-8 flex flex-wrap justify-center gap-3'>
           {links.map(({ href, label }) => (
             <a
               key={href}
               href={href}
               target='_blank'
               rel='noopener noreferrer'
-              className='inline-flex items-center gap-2 rounded-full border-2 border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 transition-all duration-200 hover:-translate-y-0.5 hover:border-[#ff5e48] hover:text-[#ff5e48]'
+              className='inline-flex items-center gap-2 rounded-full border-2 border-gray-200 bg-white px-6 py-3 text-sm font-semibold text-gray-900 transition-all duration-200 hover:-translate-y-0.5 hover:border-[#ff5e48] hover:text-[#ff5e48]'
             >
               {label}
             </a>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,45 +1,30 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/cn'
-import { HeaderVariant } from './Header.variants'
 
-type HeaderProps = VariantProps<typeof HeaderVariant>
-
-const navLinks = [
-  { href: '/hooks', label: 'Hooks' },
-  { href: '/about', label: 'About' },
-]
-
-export default function Header({ variant, sticky }: HeaderProps) {
-  const pathname = usePathname()
-
+export default function Header() {
   return (
-    <header className={cn(HeaderVariant({ variant, sticky }))}>
-      <div className='mx-auto flex h-full max-w-6xl items-center justify-between px-6'>
-        <Link href='/' className='flex items-center gap-2'>
+    <header className='sticky top-0 z-50 h-16 border-b border-gray-100 bg-white/80 backdrop-blur-md'>
+      <div className='mx-auto flex h-full max-w-6xl items-center justify-between px-6 sm:px-8'>
+        <Link
+          href='/'
+          className='flex items-center gap-2 transition-opacity hover:opacity-80'
+        >
           <span className='text-xl'>🎮</span>
-          <span className='font-bold tracking-tight'>React Playground</span>
+          <span className={cn('font-bold tracking-[-0.01em]')}>
+            React <span className='text-[#ff5e48]'>Quest</span>
+          </span>
         </Link>
 
-        <nav className='flex items-center gap-6'>
-          {navLinks.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className={cn(
-                'text-sm font-medium transition-colors',
-                pathname === href
-                  ? 'text-orange-500'
-                  : 'text-gray-700 hover:text-gray-900'
-              )}
-            >
-              {label}
-            </Link>
-          ))}
-        </nav>
+        <a
+          href='https://github.com/jerryko570/jerry-react-quest'
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-sm font-medium text-gray-600 transition hover:text-[#ff5e48]'
+        >
+          💻 GitHub
+        </a>
       </div>
     </header>
   )

--- a/src/components/quest/Achievement.tsx
+++ b/src/components/quest/Achievement.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Text from '@/components/ui/Text'
 import { cn } from '@/lib/cn'
 import { achievements } from '@/data/achievements'
 import { useProgress } from '@/lib/progress'
@@ -14,10 +15,10 @@ export default function AchievementGrid() {
           <div
             key={a.id}
             className={cn(
-              'relative rounded-2xl border-2 p-5 text-center transition-all duration-300',
+              'relative rounded-2xl p-6 text-center ring-1 transition-all duration-300',
               unlocked
-                ? 'border-[#f59e0b] bg-[#fef3c7]'
-                : 'border-gray-100 bg-white opacity-40 grayscale'
+                ? 'bg-[#fff8ec] ring-amber-300'
+                : 'bg-white opacity-40 ring-gray-100 grayscale'
             )}
           >
             {unlocked && (
@@ -25,9 +26,13 @@ export default function AchievementGrid() {
                 NEW
               </span>
             )}
-            <div className='mb-2 text-4xl'>{a.emoji}</div>
-            <div className='mb-1 text-[13px] font-bold'>{a.title}</div>
-            <div className='text-[11px] text-gray-500'>{a.description}</div>
+            <div className='mb-3 text-5xl'>{a.emoji}</div>
+            <Text as='caption' className='block font-bold'>
+              {a.title}
+            </Text>
+            <Text as='caption' className='mt-1 block text-gray-500'>
+              {a.description}
+            </Text>
           </div>
         )
       })}

--- a/src/components/quest/QuestTabs.tsx
+++ b/src/components/quest/QuestTabs.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import Text from '@/components/ui/Text'
 import {
   allStages,
   categoryMeta,
@@ -31,10 +32,10 @@ export default function QuestTabs({ initialTab }: QuestTabsProps) {
   }
 
   return (
-    <section className='mb-12'>
+    <div>
       <nav
         aria-label='Quest 카테고리'
-        className='-mx-2 mb-6 flex flex-wrap gap-2 overflow-x-auto px-2'
+        className='-mx-2 mb-8 flex flex-wrap gap-2 overflow-x-auto px-2'
       >
         {categoryMeta.map((meta) => {
           const inCategory = allStages.filter((s) => s.category === meta.id)
@@ -57,18 +58,22 @@ export default function QuestTabs({ initialTab }: QuestTabsProps) {
         })}
       </nav>
 
-      <header className='mb-6 border-b-2 border-gray-100 pb-4'>
-        <h2 className='mb-1 text-2xl font-extrabold'>
-          {activeMeta.emoji} {activeMeta.label}{' '}
-          {activeMeta.badge && (
-            <span className='text-[#ff5e48]'>{activeMeta.badge}</span>
-          )}
-        </h2>
-        <p className='text-sm text-gray-500'>{activeMeta.sublabel}</p>
+      <header className='mb-6 flex items-baseline gap-3'>
+        <Text as='h4' className='font-extrabold'>
+          {activeMeta.emoji} {activeMeta.label}
+        </Text>
+        {activeMeta.badge && (
+          <Text as='body' className='font-bold text-[#ff5e48]'>
+            {activeMeta.badge}
+          </Text>
+        )}
       </header>
+      <Text as='p' className='mb-8 text-gray-500'>
+        {activeMeta.sublabel}
+      </Text>
 
       <StageList stages={visible} />
-    </section>
+    </div>
   )
 }
 
@@ -92,7 +97,7 @@ function TabButton({
       onClick={() => onSelect(meta.id)}
       aria-current={isActive ? 'page' : undefined}
       className={cn(
-        'inline-flex shrink-0 items-center gap-2 rounded-full border-2 px-4 py-2 text-sm font-bold transition-all duration-200',
+        'inline-flex shrink-0 items-center gap-2 rounded-full border-2 px-5 py-2.5 text-sm font-bold transition-all duration-200',
         isActive
           ? 'border-[#ff5e48] bg-[#ff5e48] text-white shadow-[0_4px_12px_-4px_rgba(255,94,72,0.5)]'
           : cleared
@@ -112,7 +117,7 @@ function TabButton({
       )}
       <span
         className={cn(
-          'rounded-full px-1.5 font-mono text-[11px]',
+          'rounded-full px-2 font-mono text-[11px]',
           isActive
             ? 'bg-white/20 text-white'
             : cleared
@@ -129,13 +134,13 @@ function TabButton({
 function StageList({ stages }: { stages: Stage[] }) {
   if (stages.length === 0) {
     return (
-      <div className='rounded-2xl bg-gray-50 py-12 text-center text-sm text-gray-500'>
+      <div className='rounded-2xl bg-gray-50 py-16 text-center text-sm text-gray-500'>
         이 탭은 아직 준비 중이에요
       </div>
     )
   }
   return (
-    <div className='flex flex-col gap-4'>
+    <div className='grid gap-4 sm:grid-cols-2'>
       {stages.map((stage) => (
         <StageCard key={stage.id} stage={stage} />
       ))}

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import Text from '@/components/ui/Text'
 import type { Stage } from '@/data/stages'
 import { hasPlayground } from '@/data/playgrounds'
 import { isCompleted, useProgress } from '@/lib/progress'
@@ -19,7 +20,6 @@ export default function StageCard({ stage }: StageCardProps) {
   const progress = useProgress()
   const done = isCompleted(stage.id, progress)
   const playgroundReady = hasPlayground(stage.id)
-  // 놀이기구가 등록된 스테이지는 자동으로 '진행 가능' 처리
   const baseStatus =
     stage.status === 'locked' && playgroundReady ? 'active' : stage.status
   const effectiveStatus = done ? 'completed' : baseStatus
@@ -36,7 +36,7 @@ export default function StageCard({ stage }: StageCardProps) {
       aria-label={`${stage.title} 상세로 이동`}
       className={cn(
         stageCardVariants({ status: effectiveStatus, boss: stage.isBoss }),
-        'block focus-visible:ring-2 focus-visible:ring-[#ff5e48] focus-visible:outline-none',
+        'block p-6 focus-visible:ring-2 focus-visible:ring-[#ff5e48] focus-visible:outline-none',
         effectiveStatus === 'locked' && 'hover:translate-y-0 hover:shadow-none'
       )}
     >
@@ -46,32 +46,36 @@ export default function StageCard({ stage }: StageCardProps) {
       {done && (
         <div
           aria-hidden
-          className='pointer-events-none absolute top-3 right-4 -rotate-12 rounded-md border-2 border-emerald-500 px-3 py-1 font-mono text-sm font-black tracking-wider text-emerald-500 opacity-90'
+          className='pointer-events-none absolute top-4 right-5 -rotate-12 rounded-md border-2 border-emerald-500 px-3 py-1 font-mono text-sm font-black tracking-wider text-emerald-500 opacity-90'
         >
           CLEAR!
         </div>
       )}
 
-      <header className='mb-4 flex items-start justify-between gap-3'>
-        <div className='flex flex-1 items-center gap-4'>
-          <span className='shrink-0 text-4xl'>{stage.emoji}</span>
-          <div>
-            <h3 className='text-xl font-extrabold tracking-[-0.01em]'>
+      <header className='flex items-start justify-between gap-4'>
+        <div className='flex flex-1 items-start gap-4'>
+          <span className='shrink-0 text-5xl'>{stage.emoji}</span>
+          <div className='flex-1'>
+            <Text as='h6' className='font-extrabold'>
               {stage.title}
-            </h3>
-            <p className='text-sm text-gray-500'>{stage.subtitle}</p>
-            <div className='mt-2 flex flex-wrap items-center gap-1.5'>
+            </Text>
+            <Text as='p' className='mt-1 text-gray-500'>
+              {stage.subtitle}
+            </Text>
+            <div className='mt-3 flex flex-wrap items-center gap-2'>
               <span
                 className={difficultyBadge({ difficulty: stage.difficulty })}
               >
                 {difficultyLabel[stage.difficulty]}
               </span>
               {stage.highlight && !done && (
-                <span className='text-xs font-bold text-[#ff5e48]'>
+                <Text as='caption' className='font-bold text-[#ff5e48]'>
                   {stage.highlight}
-                </span>
+                </Text>
               )}
-              <span className='text-xs text-gray-500'>⏱ {stage.hours}시간</span>
+              <Text as='caption' className='text-gray-500'>
+                ⏱ {stage.hours}시간
+              </Text>
               {playgroundReady && (
                 <span className='inline-flex items-center gap-1 rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-bold text-white'>
                   🕹️ 플레이 가능
@@ -83,13 +87,8 @@ export default function StageCard({ stage }: StageCardProps) {
         <div className='shrink-0 text-2xl'>{statusIcon}</div>
       </header>
 
-      <div className='grid gap-5 border-t border-gray-100 pt-4 md:grid-cols-2'>
-        <Bullets title='🎯 학습 목표' items={stage.goals} />
-        <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
-      </div>
-
       {stage.progress && !done && (
-        <footer className='mt-4 flex items-center justify-between border-t border-gray-100 pt-4 text-sm text-gray-500'>
+        <footer className='mt-5 flex items-center justify-between border-t border-gray-100 pt-4 text-sm text-gray-500'>
           <span>{stage.progress.label}</span>
           <div className='flex items-center gap-2'>
             <div className='h-1.5 w-24 overflow-hidden rounded-full bg-gray-100'>
@@ -109,26 +108,5 @@ export default function StageCard({ stage }: StageCardProps) {
         </footer>
       )}
     </Link>
-  )
-}
-
-function Bullets({ title, items }: { title: string; items: string[] }) {
-  return (
-    <div>
-      <div className='mb-2 flex items-center gap-1.5 text-xs font-bold tracking-[0.08em] text-gray-500 uppercase'>
-        {title}
-      </div>
-      <ul className='flex flex-col gap-1.5'>
-        {items.map((text) => (
-          <li
-            key={text}
-            className='flex items-start gap-2 text-sm leading-snug'
-          >
-            <span className='shrink-0 font-mono text-gray-500'>☐</span>
-            <span>{text}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
   )
 }

--- a/src/components/stages/StageDetail.tsx
+++ b/src/components/stages/StageDetail.tsx
@@ -1,4 +1,7 @@
 import Link from 'next/link'
+import Text from '@/components/ui/Text'
+import Section from '@/components/ui/Section'
+import FadeIn from '@/components/ui/FadeIn'
 import { categoryMeta, type Stage } from '@/data/stages'
 import { hasPlayground, playgrounds } from '@/data/playgrounds'
 import {
@@ -17,101 +20,83 @@ export default function StageDetail({ stage }: Props) {
   const Playground = playgrounds[stage.id]
 
   return (
-    <div className='mx-auto max-w-240 px-6 py-10'>
-      <nav className='mb-6 flex flex-wrap items-center gap-1 text-sm text-gray-500'>
-        <Link href='/' className='hover:text-[#ff5e48]'>
-          🎮 Quest
-        </Link>
-        <span>/</span>
-        <Link href={`/?tab=${stage.category}`} className='hover:text-[#ff5e48]'>
-          {category?.emoji} {category?.label}
-        </Link>
-        <span>/</span>
-        <span className='font-semibold text-gray-800'>{stage.title}</span>
-      </nav>
-
-      <header className='mb-8'>
-        <div className='mb-3 flex items-center gap-3'>
-          <span className='text-5xl'>{stage.emoji}</span>
-          <div>
-            <h1 className='text-3xl font-extrabold tracking-tight sm:text-4xl'>
-              {stage.title}
-            </h1>
-            <p className='mt-1 text-gray-500'>{stage.subtitle}</p>
-          </div>
-        </div>
-        <div className='flex flex-wrap items-center gap-2'>
-          <span className={difficultyBadge({ difficulty: stage.difficulty })}>
-            {difficultyLabel[stage.difficulty]}
-          </span>
-          {stage.highlight && (
-            <span className='text-xs font-bold text-[#ff5e48]'>
-              {stage.highlight}
-            </span>
-          )}
-          <span className='text-xs text-gray-500'>⏱ {stage.hours}시간</span>
-          {stage.status === 'locked' && !hasPlayground(stage.id) && (
-            <span className='ml-2 text-xs font-bold text-gray-500'>
-              🔒 잠김 — 미리보기
-            </span>
-          )}
-        </div>
-      </header>
-
-      <section className='mb-10 grid gap-5 rounded-2xl bg-white p-6 ring-1 ring-gray-100 md:grid-cols-2'>
-        <Bullets title='🎯 학습 목표' items={stage.goals} />
-        <Bullets title={`🎮 ${stage.examplesLabel}`} items={stage.examples} />
-      </section>
-
-      <section>
-        <div className='mb-4 flex items-end justify-between'>
-          <h2 className='text-xl font-extrabold'>🕹️ 놀이기구</h2>
-          {Playground && (
-            <span className='text-xs text-gray-500'>
-              아래에서 직접 눌러보고 망가뜨려봐
-            </span>
-          )}
-        </div>
-        {Playground ? (
-          <Playground />
-        ) : (
-          <PlaygroundPlaceholder stageTitle={stage.title} />
-        )}
-      </section>
-
-      <section className='mt-10'>
-        <CompleteButton stageId={stage.id} />
-      </section>
-
-      <div className='mt-10 flex justify-center'>
-        <Link
-          href={`/?tab=${stage.category}`}
-          className='inline-flex items-center gap-2 rounded-full border-2 border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 hover:border-[#ff5e48] hover:text-[#ff5e48]'
-        >
-          ← {category?.emoji} {category?.label} 로 돌아가기
-        </Link>
-      </div>
-    </div>
-  )
-}
-
-function Bullets({ title, items }: { title: string; items: string[] }) {
-  return (
-    <div>
-      <div className='mb-2 text-xs font-bold tracking-[0.08em] text-gray-500 uppercase'>
-        {title}
-      </div>
-      <ul className='flex flex-col gap-1.5'>
-        {items.map((text) => (
-          <li
-            key={text}
-            className='flex items-start gap-2 text-sm leading-snug'
+    <>
+      <Section padding='md'>
+        <nav className='mb-6 flex flex-wrap items-center gap-1.5 text-sm text-gray-500'>
+          <Link href='/' className='hover:text-[#ff5e48]'>
+            🎮 Quest
+          </Link>
+          <span>/</span>
+          <Link
+            href={`/?tab=${stage.category}`}
+            className='hover:text-[#ff5e48]'
           >
-            <span className='shrink-0 font-mono text-gray-400'>▸</span>
-            <span>{text}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
+            {category?.emoji} {category?.label}
+          </Link>
+          <span>/</span>
+          <span className='font-semibold text-gray-800'>{stage.title}</span>
+        </nav>
+
+        <FadeIn>
+          <header className='flex flex-col gap-5'>
+            <div className='flex items-center gap-5'>
+              <span className='text-6xl sm:text-7xl'>{stage.emoji}</span>
+              <div>
+                <Text as='h2' className='font-extrabold'>
+                  {stage.title}
+                </Text>
+                <Text as='body' className='mt-2 text-gray-500'>
+                  {stage.subtitle}
+                </Text>
+              </div>
+            </div>
+            <div className='flex flex-wrap items-center gap-2'>
+              <span
+                className={difficultyBadge({ difficulty: stage.difficulty })}
+              >
+                {difficultyLabel[stage.difficulty]}
+              </span>
+              {stage.highlight && (
+                <Text as='caption' className='font-bold text-[#ff5e48]'>
+                  {stage.highlight}
+                </Text>
+              )}
+              <Text as='caption' className='text-gray-500'>
+                ⏱ {stage.hours}시간
+              </Text>
+              {stage.status === 'locked' && !hasPlayground(stage.id) && (
+                <Text as='caption' className='ml-2 font-bold text-gray-500'>
+                  🔒 잠김 — 미리보기
+                </Text>
+              )}
+            </div>
+          </header>
+        </FadeIn>
+      </Section>
+
+      <Section padding='md' className='bg-white'>
+        <FadeIn delay={0.1}>
+          {Playground ? (
+            <Playground />
+          ) : (
+            <PlaygroundPlaceholder stageTitle={stage.title} />
+          )}
+        </FadeIn>
+      </Section>
+
+      <Section padding='md'>
+        <FadeIn>
+          <CompleteButton stageId={stage.id} />
+        </FadeIn>
+        <div className='mt-10 flex justify-center'>
+          <Link
+            href={`/?tab=${stage.category}`}
+            className='inline-flex items-center gap-2 rounded-full border-2 border-gray-200 bg-white px-6 py-3 text-sm font-semibold text-gray-700 transition hover:-translate-y-0.5 hover:border-[#ff5e48] hover:text-[#ff5e48]'
+          >
+            ← {category?.emoji} {category?.label}로 돌아가기
+          </Link>
+        </div>
+      </Section>
+    </>
   )
 }

--- a/src/components/ui/Card/Card.variants.ts
+++ b/src/components/ui/Card/Card.variants.ts
@@ -1,11 +1,11 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 
-export const CardVariant = cva('flex rounded-lg', {
+export const CardVariant = cva('flex rounded-2xl transition-all duration-300', {
   variants: {
     theme: {
       dark: 'bg-gray-800 text-white',
       gray: 'bg-gray-100 text-gray-900',
-      white: 'bg-white text-gray-900',
+      white: 'bg-white text-gray-900 ring-1 ring-gray-100',
       lightOrange: 'bg-orange-50 text-gray-900',
       sky: 'bg-blue-500 text-white',
       lightSky: 'bg-blue-200 text-gray-900',
@@ -20,7 +20,7 @@ export const CardVariant = cva('flex rounded-lg', {
       lg: 'p-10',
     },
     interactive: {
-      true: 'cursor-pointer transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg',
+      true: 'cursor-pointer hover:-translate-y-0.5 hover:shadow-lg',
       false: '',
     },
   },

--- a/src/components/ui/Card/FeatureCard.tsx
+++ b/src/components/ui/Card/FeatureCard.tsx
@@ -1,0 +1,45 @@
+import { CardVariant, type CardVariantProps } from './Card.variants'
+import Text from '@/components/ui/Text'
+import { cn } from '@/lib/cn'
+
+type Props = {
+  title: string
+  description: string | string[]
+  value: string
+  className?: string
+} & CardVariantProps
+
+export default function FeatureCard({
+  title,
+  description,
+  value,
+  theme,
+  padding = 'md',
+  className,
+}: Props) {
+  const descriptions = Array.isArray(description) ? description : [description]
+
+  return (
+    <div
+      className={cn(
+        CardVariant({ theme, padding }),
+        'flex-col items-center text-center',
+        className
+      )}
+    >
+      <Text as='h3' className='font-extrabold text-orange-500'>
+        {value}
+      </Text>
+      <Text as='body' className='mt-4 font-medium'>
+        {title}
+      </Text>
+      <div className='mt-1'>
+        {descriptions.map((d, i) => (
+          <Text as='p' key={i} className='pt-1 text-gray-400'>
+            {d}
+          </Text>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/Card/HighlightCard.tsx
+++ b/src/components/ui/Card/HighlightCard.tsx
@@ -1,0 +1,47 @@
+import { CardVariant, type CardVariantProps } from './Card.variants'
+import Text from '@/components/ui/Text'
+import { cn } from '@/lib/cn'
+
+type Props = {
+  tag?: string
+  title: string
+  description?: string
+  icon?: string
+  className?: string
+} & CardVariantProps
+
+export default function HighlightCard({
+  tag,
+  title,
+  description,
+  icon,
+  theme,
+  padding = 'md',
+  interactive,
+  className,
+}: Props) {
+  return (
+    <div
+      className={cn(
+        CardVariant({ theme, padding, interactive }),
+        'flex-col text-center',
+        className
+      )}
+    >
+      {icon && <div className='mb-2 text-4xl'>{icon}</div>}
+      {tag && (
+        <Text as='caption' className='font-bold text-orange-500'>
+          {tag}
+        </Text>
+      )}
+      <Text as='h6' className={cn(tag && 'mt-2')}>
+        {title}
+      </Text>
+      {description && (
+        <Text as='p' className='mt-3 text-gray-500'>
+          {description}
+        </Text>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/Card/NumberCard.tsx
+++ b/src/components/ui/Card/NumberCard.tsx
@@ -1,0 +1,39 @@
+import Badge from '@/components/ui/Badge'
+import type { BadgeProps } from '@/components/ui/Badge/Badge'
+import { CardVariant, type CardVariantProps } from './Card.variants'
+import Text from '@/components/ui/Text'
+import { cn } from '@/lib/cn'
+
+type Props = {
+  number: string
+  title: string
+  description?: string
+  badgeTheme?: BadgeProps['theme']
+  className?: string
+} & CardVariantProps
+
+export default function NumberCard({
+  number,
+  title,
+  description,
+  theme,
+  padding = 'md',
+  badgeTheme = 'orange',
+  className,
+}: Props) {
+  return (
+    <div className={cn(CardVariant({ theme, padding }), 'flex-col', className)}>
+      <Badge label={number} size='xs' theme={badgeTheme} weight='bold' />
+      <div className='mt-3'>
+        <Text as='body' className='font-medium'>
+          {title}
+        </Text>
+        {description && (
+          <Text as='p' className='mt-2 text-gray-500'>
+            {description}
+          </Text>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/Card/index.ts
+++ b/src/components/ui/Card/index.ts
@@ -1,3 +1,6 @@
 export { default } from './Card'
+export { default as HighlightCard } from './HighlightCard'
+export { default as FeatureCard } from './FeatureCard'
+export { default as NumberCard } from './NumberCard'
 export { CardVariant } from './Card.variants'
-export type { CardTheme } from './Card.variants'
+export type { CardTheme, CardVariantProps } from './Card.variants'

--- a/src/components/ui/FadeIn.tsx
+++ b/src/components/ui/FadeIn.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { motion } from 'motion/react'
+import type { ReactNode } from 'react'
+
+type FadeInProps = {
+  children: ReactNode
+  delay?: number
+  duration?: number
+  y?: number
+  className?: string
+  amount?: number
+}
+
+export default function FadeIn({
+  children,
+  delay = 0,
+  duration = 0.6,
+  y = 30,
+  className,
+  amount = 0.2,
+}: FadeInProps) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount }}
+      transition={{ duration, delay, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/cn'
+
+type Props = {
+  children: React.ReactNode
+  className?: string
+  maxWidth?: string
+  padding?: 'sm' | 'md' | 'lg' | 'none'
+}
+
+const paddingMap: Record<NonNullable<Props['padding']>, string> = {
+  none: '',
+  sm: 'py-10 px-6',
+  md: 'py-16 px-6 sm:px-8',
+  lg: 'py-24 px-6 sm:px-12',
+}
+
+export default function Section({
+  children,
+  className,
+  maxWidth = 'max-w-6xl',
+  padding = 'md',
+}: Props) {
+  return (
+    <section className={className}>
+      <div className={cn('mx-auto', maxWidth, paddingMap[padding])}>
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,57 @@
+import Badge from '@/components/ui/Badge'
+import Text from '@/components/ui/Text'
+import type { VariantProps } from 'class-variance-authority'
+import { BadgeVariants } from '@/components/ui/Badge/Badge.variants'
+import { cn } from '@/lib/cn'
+
+type SectionHeaderProps = {
+  badge?: string
+  title?: string
+  subtitle?: string
+  description?: string
+  align?: 'left' | 'center'
+  titleSize?: 'display' | 'h1' | 'h2' | 'h3' | 'h4'
+  badgeTheme?: VariantProps<typeof BadgeVariants>['theme']
+  className?: string
+}
+
+export default function SectionHeader({
+  badge,
+  title,
+  subtitle,
+  description,
+  align = 'left',
+  titleSize = 'h2',
+  badgeTheme = 'orange',
+  className,
+}: SectionHeaderProps) {
+  const textAlign =
+    align === 'center' ? 'items-center text-center' : 'items-start text-left'
+
+  return (
+    <div className={cn('flex flex-col', textAlign, className)}>
+      {badge && <Badge label={badge} size='md' theme={badgeTheme} />}
+      {title && (
+        <Text
+          as={titleSize}
+          className={cn('break-keep whitespace-pre-line', badge && 'mt-4')}
+        >
+          {title}
+        </Text>
+      )}
+      {subtitle && (
+        <Text
+          as='h4'
+          className='mt-4 break-keep whitespace-pre-line text-gray-600'
+        >
+          {subtitle}
+        </Text>
+      )}
+      {description && (
+        <Text as='body' className='mt-4 whitespace-pre-line text-gray-600'>
+          {description}
+        </Text>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/Text/Text.tsx
+++ b/src/components/ui/Text/Text.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { VariantProps } from 'class-variance-authority'
+import { textVariant } from './Text.variants'
+import { cn } from '@/lib/cn'
+
+type AsType = NonNullable<VariantProps<typeof textVariant>['as']>
+
+type TextProps = {
+  as?: AsType
+  children: React.ReactNode
+  className?: string
+} & Omit<VariantProps<typeof textVariant>, 'as'> &
+  React.HTMLAttributes<HTMLElement>
+
+const elementMap: Record<AsType, React.ElementType> = {
+  display: 'h1',
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
+  body: 'p',
+  p: 'p',
+  caption: 'span',
+}
+
+export default function Text({
+  as = 'p',
+  children,
+  className,
+  ...rest
+}: TextProps) {
+  const Tag = elementMap[as]
+
+  return (
+    <Tag className={cn(textVariant({ as }), className)} {...rest}>
+      {children}
+    </Tag>
+  )
+}

--- a/src/components/ui/Text/Text.variants.ts
+++ b/src/components/ui/Text/Text.variants.ts
@@ -1,0 +1,21 @@
+import { cva } from 'class-variance-authority'
+
+export const textVariant = cva('', {
+  variants: {
+    as: {
+      display: 'text-[4.5rem] leading-[1.2] font-extrabold tracking-[-0.02em]',
+      h1: 'text-[3.5rem] leading-[1.3] font-bold tracking-[-0.02em]',
+      h2: 'text-[3rem] leading-[1.3] font-bold tracking-[-0.01em]',
+      h3: 'text-[2.5rem] leading-[1.3] font-semibold',
+      h4: 'text-[2rem] leading-[1.4] font-semibold',
+      h5: 'text-[1.75rem] leading-[1.5] font-medium',
+      h6: 'text-[1.5rem] leading-[1.5] font-medium',
+      body: 'text-[1.25rem] leading-[1.6] font-normal',
+      p: 'text-[1rem] leading-[1.8] font-normal',
+      caption: 'text-[0.875rem] leading-[1.4] font-normal',
+    },
+  },
+  defaultVariants: {
+    as: 'p',
+  },
+})

--- a/src/components/ui/Text/index.ts
+++ b/src/components/ui/Text/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Text'
+export { textVariant } from './Text.variants'


### PR DESCRIPTION
closes #32

narae-ux-portfolio 컴포넌트 이식 + 홈/상세 섹션 리디자인.

## 이식된 UI 프리미티브
- **Text** — display/h1~h6/body/p/caption 타이포 variant
- **Section** — max-width + padding 래퍼
- **SectionHeader** — badge + title + subtitle + description
- **FadeIn** — motion/react 스크롤 페이드인
- **Card 3종**: HighlightCard · FeatureCard · NumberCard
- Card.variants 확장 (rounded-2xl · transition · padding · interactive)

## 리디자인

**홈 (`/`)**
- Hero: display 타이포 + Badge + 설명
- Dashboard: Badge/Text 기반 정돈
- Roadmap: SectionHeader + 탭
- Achievements: 독립 섹션 + ring-1 스타일 카드

**스테이지 상세 (`/stages/[id]`)**
- 3 Section 분할: 헤더 / 놀이기구 / 정복+뒤로
- FadeIn 전면 적용
- 기존 "학습 목표 + 예제" 중복 카드 제거 (놀이기구 자체에 이미 있음)

**Header / Footer**
- Header: sticky + backdrop-blur, 우측 GitHub 링크
- Footer: Section 기반 패딩, 더 넓은 여백

## 범위 외
- 놀이기구 내부(BasicPlay/DeepenPlay 등) 디자인은 그대로 — 다음 PR 예정

## 검증
`npm run build` ✓ / `npm run lint` ✓ / HTTP 200
