### PR TITLE
🐛 Fix: 렌더링 기초 디테일 5가지

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,8 @@ import { jetbrainsMono } from './fonts'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: '🎮 React Playground',
-  description: '개념을 눌러보고, 망가뜨리고, 체화하는 놀이터',
+  title: '🎮 React Quest',
+  description: '개념을 눌러보고, 망가뜨리고, 체험하는 놀이터',
 }
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default async function Home({ searchParams }: HomeProps) {
           <div className='flex flex-col items-center text-center'>
             <Badge label='🎮 React Quest' theme='orange' size='md' />
             <Text as='display' className='mt-6 break-keep whitespace-pre-line'>
-              {`훅을 눌러보고\n망가뜨리며 체화하는 `}
+              {`훅을 눌러보고\n망가뜨리며 체험하는 `}
               <span className='text-orange-500'>놀이터</span>
             </Text>
             <Text as='body' className='mt-6 max-w-xl text-gray-500'>
@@ -48,7 +48,7 @@ export default async function Home({ searchParams }: HomeProps) {
           <SectionHeader
             badge='🗺 로드맵'
             title='어디서부터 시작해볼까?'
-            description='5개 탭 · 28개 스테이지 · 클리어하면 뱃지 자동 해금'
+            description='5개 탭 · 28개 스테이지 · 클리어 하면 뱃지 자동 해제'
           />
         </FadeIn>
         <div className='mt-10'>

--- a/src/components/playgrounds/rendering/BasicPlay.tsx
+++ b/src/components/playgrounds/rendering/BasicPlay.tsx
@@ -1,23 +1,18 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 type ChildProps = { id: string }
 
 function Child({ id }: ChildProps) {
-  const renders = useRef(0)
-  // 교육용 렌더 카운터 — 의도적으로 렌더 중 ref 조작
-  // eslint-disable-next-line react-hooks/refs
-  renders.current += 1
-  // eslint-disable-next-line react-hooks/refs
-  const count = renders.current
+  const stamp = new Date().toLocaleTimeString('ko-KR', { hour12: false })
   return (
     <div className='flex flex-col items-center gap-1 rounded-2xl bg-white p-5 text-center ring-1 ring-gray-200'>
       <span className='text-3xl'>{id}</span>
       <span className='text-[11px] font-semibold tracking-wider text-gray-500 uppercase'>
-        내가 그려진 횟수
+        마지막으로 그려진 시각
       </span>
-      <span className='font-mono text-3xl font-extrabold'>{count}</span>
+      <span className='font-mono text-xl font-extrabold'>{stamp}</span>
     </div>
   )
 }

--- a/src/components/playgrounds/rendering/index.tsx
+++ b/src/components/playgrounds/rendering/index.tsx
@@ -1,5 +1,6 @@
 import BasicPlay from './BasicPlay'
 import DeepenPlay from './DeepenPlay'
+import CodeBlock from '@/components/stages/CodeBlock'
 import StageFlow from '@/components/stages/StageFlow'
 
 export default function RenderingPlayground() {
@@ -10,37 +11,64 @@ export default function RenderingPlayground() {
         처음엔 당황했거든.
       </StageFlow.Empathy>
 
-      <StageFlow.Play subtitle='버튼 눌러봐. 숫자 3개가 뭘 하는지만 봐'>
+      <StageFlow.Play subtitle='버튼 눌러봐. 🟢🔵🟠의 시각이 같이 바뀌는지만 봐'>
         <BasicPlay />
       </StageFlow.Play>
 
       <StageFlow.Observe
-        title='🤔 어? 내가 안 건드린 🟢🔵🟠도 숫자가 올랐네?'
+        title='🤔 어? 내가 안 건드렸는데 🟢🔵🟠 시각이 같이 움직이네?'
         subtitle='왜 그랬을까?'
       >
         <p>
-          부모가 &quot;다시 그리기&quot; (= 리렌더) 되면 자식 세 명도 덩달아
-          다시 그려져. 리액트는 원래 이렇게 움직여 — 자식 &quot;부모가 준
-          값&quot; (= props)이 안 바뀌었어도 그래.
+          🟢 부모가 &quot;다시 그리기&quot;(= 리렌더) 되면 자식 세 명도 덩달아
+          같이 그려져.
+        </p>
+        <p className='mt-2'>
+          🟢 자식 &quot;부모가 준 값&quot;(= props)이 안 바뀌었어도 그래 —
+          리액트는 원래 이렇게 움직이거든.
         </p>
       </StageFlow.Observe>
 
       <StageFlow.Deepen
-        title='🛡️ 자식에게 방패 씌우고 다시 눌러봐'
-        subtitle='이번엔 토글 ON'
+        title='🛡️ 자식에게 방패 켜고 다시 눌러봐'
+        subtitle='퀴즈까지 이어서'
       >
         <DeepenPlay />
-        <p className='mt-3 text-[13px] text-gray-700'>
-          🔍 방패 켜면 자식이 &quot;나 props 그대로인데 굳이 다시 그려?&quot;
-          하고 건너뛰어. 이게 <code>React.memo</code>가 하는 일이야.
-        </p>
       </StageFlow.Deepen>
 
-      <StageFlow.Next subtitle='한 줄 정리 + 다음'>
-        <p className='mb-2'>
+      <StageFlow.Next subtitle='코드 비교 + 한 줄 정리 + 다음'>
+        <p className='mb-3'>
           ✔️ <b>부모가 그려지면 자식도 같이 그려진다</b> — 이게 기본.
         </p>
-        <p className='text-gray-700'>
+        <p className='mb-4'>
+          방패(<code>React.memo</code>)를 씌우면 props가 같을 때만 자식이
+          건너뛰어. 코드로는 이렇게 달라.
+        </p>
+        <div className='grid gap-3 md:grid-cols-2'>
+          <div>
+            <div className='mb-2 inline-block rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-bold text-red-800'>
+              🚫 방패 없음 — 부모 따라 매번 그려짐
+            </div>
+            <CodeBlock
+              filename='Child.tsx'
+              code={`function Child({ id }) {
+  return <div>{id}</div>
+}`}
+            />
+          </div>
+          <div>
+            <div className='mb-2 inline-block rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-800'>
+              ✅ 방패 있음 — props 같으면 스킵
+            </div>
+            <CodeBlock
+              filename='Child.tsx'
+              code={`const Child = memo(function Child({ id }) {
+  return <div>{id}</div>
+})`}
+            />
+          </div>
+        </div>
+        <p className='mt-4 text-gray-700'>
           다음은 &quot;정말 비싼 계산&quot;을 기억해두기(= 메모이제이션)로
           건너뛰는 <b>useMemo</b> 차례야 🚀
         </p>


### PR DESCRIPTION
사용자 피드백 직반영:
1. 초기 숫자 정렬 (StrictMode로 부모 0 / 자식 2 → 시각 표시로 교체)
2. 방패 용어 일관화 (꺼짐/켜짐)
3. Next 섹션에 실제 Before/After 코드 비교 추가
4. Observe 파란 박스 2줄로 분리
5. 심화 끝에 확인 퀴즈 버튼 + 피드백

bonus: metadata title 'React Playground' → 'React Quest' 일관화