### PR TITLE
🎨Style: 홈 뱃지 블루 · Dashboard 진도 레이블 키움

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,7 @@ export default async function Home({ searchParams }: HomeProps) {
         <SectionHeader
           badge='🗺 로드맵'
           title='어디서부터 시작해볼까?'
+          badgeTheme='blue'
           description='5개 탭 · 28개 스테이지 · 클리어 하면 뱃지 자동 해제'
         />
         <div className='mt-10'>
@@ -53,6 +54,7 @@ export default async function Home({ searchParams }: HomeProps) {
       <Section padding='lg' className='bg-white'>
         <SectionHeader
           badge='🏆 뱃지'
+          badgeTheme='blue'
           title='오늘 어디까지 왔어?'
           description='스테이지를 정복할 때마다 자동으로 해금돼'
         />

--- a/src/components/quest/Dashboard.tsx
+++ b/src/components/quest/Dashboard.tsx
@@ -24,7 +24,7 @@ export default function Dashboard({
     <section className='mb-12 rounded-3xl bg-linear-to-br from-[#4576fc] to-[#5f8aff] p-8 text-white shadow-[0_20px_40px_-20px_rgba(69,118,252,0.4)]'>
       <div className='mb-5 flex flex-wrap items-end justify-between gap-3'>
         <div>
-          <div className='text-xs font-semibold tracking-widest uppercase opacity-90'>
+          <div className='text-xl font-semibold tracking-widest uppercase opacity-90'>
             ⚔️ 전체 진도
           </div>
           <div className='mt-1 text-sm opacity-85'>


### PR DESCRIPTION
## Summary
- 홈 SectionHeader 뱃지 블루 톤 적용 (로드맵 · 뱃지)
- Dashboard '⚔️ 전체 진도' 레이블 글자 키움 (`text-xs` → `text-xl`)

## Test plan
- [ ] 홈 페이지 뱃지 블루 확인
- [ ] Dashboard 레이블 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
