### PR TITLE
🎨Style: 상세페이지 화이트 카드 통일 + 가독성 강중약

### DIFF
--- a/src/components/stages/StageDetail.tsx
+++ b/src/components/stages/StageDetail.tsx
@@ -19,7 +19,7 @@ export default function StageDetail({ stage }: Props) {
   const Playground = playgrounds[stage.id]
 
   return (
-    <Section padding='md' maxWidth='max-w-3xl'>
+    <Section padding='md' maxWidth='max-w-5xl'>
       <nav className='mb-8 flex flex-wrap items-center gap-1.5 text-sm text-gray-500'>
         <Link href='/' className='hover:text-blue-500'>
           🎮 Quest

--- a/src/components/stages/StageFlow.tsx
+++ b/src/components/stages/StageFlow.tsx
@@ -1,129 +1,87 @@
 import { ReactNode } from 'react'
-import { cn } from '@/lib/cn'
-
-type SectionKind = 'play' | 'observe' | 'deepen' | 'next'
 
 type SectionProps = {
-  step?: string
-  kind: SectionKind
   title: string
   subtitle?: string
   children: ReactNode
 }
 
-const KIND_STYLES: Record<
-  SectionKind,
-  { border: string; badge: string; bg: string }
-> = {
-  play: {
-    border: 'border-[#4576fc]',
-    badge: 'bg-[#4576fc] text-white',
-    bg: 'bg-[#f4f7ff]',
-  },
-  observe: {
-    border: 'border-emerald-300',
-    badge: 'bg-emerald-500 text-white',
-    bg: 'bg-emerald-50/60',
-  },
-  deepen: {
-    border: 'border-violet-300',
-    badge: 'bg-violet-500 text-white',
-    bg: 'bg-violet-50/60',
-  },
-  next: {
-    border: 'border-amber-300',
-    badge: 'bg-gray-900 text-white',
-    bg: 'bg-[#fff8ec]',
-  },
-}
-
-function Section({ step, kind, title, subtitle, children }: SectionProps) {
-  const s = KIND_STYLES[kind]
+function Section({ title, subtitle, children }: SectionProps) {
   return (
-    <section className={cn('rounded-2xl border-l-4 px-6 py-5', s.border, s.bg)}>
-      <header className='mb-3 flex items-center gap-3'>
-        {step && (
-          <span
-            className={cn(
-              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-mono text-sm font-black shadow-sm',
-              s.badge
-            )}
-          >
-            {step}
-          </span>
+    <section className='rounded-2xl bg-white p-8 ring-1 ring-gray-100'>
+      <header className='mb-5'>
+        <h3 className='text-2xl leading-tight font-extrabold text-gray-900'>
+          {title}
+        </h3>
+        {subtitle && (
+          <p className='mt-2 text-sm font-medium text-gray-500'>{subtitle}</p>
         )}
-        <div>
-          <h3 className='text-lg leading-tight font-extrabold'>{title}</h3>
-          {subtitle && (
-            <p className='mt-0.5 text-xs text-gray-500'>{subtitle}</p>
-          )}
-        </div>
       </header>
-      <div className='text-sm leading-relaxed text-gray-800'>{children}</div>
+      <div className='text-base leading-relaxed text-gray-700'>{children}</div>
     </section>
   )
 }
 
 function Root({ children }: { children: ReactNode }) {
-  return <div className='flex flex-col gap-4'>{children}</div>
+  return <div className='flex flex-col gap-5'>{children}</div>
 }
 
-// 공감 한 줄 — 인트로 바 (섹션 번호 없음)
+// 공감 한 줄 — 인트로 (카드 없이 큰 문장)
 function Empathy({ children }: { children: ReactNode }) {
   return (
-    <div className='rounded-2xl bg-linear-to-br from-[#f4f7ff] to-[#e7edff] px-6 py-4'>
-      <p className='text-base font-bold text-gray-800'>{children}</p>
-    </div>
+    <p className='px-2 text-lg leading-relaxed font-semibold text-gray-900'>
+      {children}
+    </p>
   )
 }
 
-// ① 실습
+// 실습
 function Play({
-  title = '🎮 일단 눌러봐',
+  title = '일단 눌러봐',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='①' kind='play' title={title!} subtitle={subtitle}>
+    <Section title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )
 }
 
-// ② 관찰 질문 + 해설 2문장
+// 관찰 + 해설
 function Observe({
-  title = '🤔 어? 이거 뭐지?',
+  title = '어? 이거 뭐지?',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='②' kind='observe' title={title!} subtitle={subtitle}>
+    <Section title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )
 }
 
-// ③ 한 단계 더 실험
+// 한 단계 더
 function Deepen({
-  title = '🔬 한 번 더, 이번엔 조건을 바꿔봐',
+  title = '한 번 더, 이번엔 조건을 바꿔봐',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='③' kind='deepen' title={title!} subtitle={subtitle}>
+    <Section title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )
 }
 
-// ④ 다음
+// 다음
 function Next({
-  title = '🚀 다음으로',
+  title = '다음으로',
   subtitle,
   children,
 }: Partial<SectionProps>) {
   return (
-    <Section step='④' kind='next' title={title!} subtitle={subtitle}>
+    <Section title={title!} subtitle={subtitle}>
       {children}
     </Section>
   )

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -22,7 +22,7 @@ export default function SectionHeader({
   description,
   align = 'left',
   titleSize = 'h2',
-  badgeTheme = 'orange',
+  badgeTheme = 'blue',
   className,
 }: SectionHeaderProps) {
   const textAlign =


### PR DESCRIPTION
## Summary
- StageFlow 전 섹션 화이트 카드 통일 (배경 · 좌측 컬러 띠 · 스텝 뱃지 제거)
- 타이틀 `text-2xl font-extrabold` / 서브 `font-medium text-gray-500` / 본문 `text-base text-gray-700` — 강중약
- Empathy 블록 카드 제거, 큰 문장으로 직접 노출
- 상세페이지 가로 폭 확장 (`max-w-3xl` → `max-w-5xl`)
- `SectionHeader` 기본 `badgeTheme` 블루

## Test plan
- [ ] `/stages/stage-1-rendering` 카드 모두 화이트 · 읽기 편한지 확인
- [ ] 상세페이지 가로가 넉넉한지 확인
- [ ] 타이틀/본문 대비 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
