### PR TITLE
🎨Style: 홈 전 섹션 화이트 카드 + 강중약 통일

### DIFF
--- a/src/components/quest/Achievement.tsx
+++ b/src/components/quest/Achievement.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Text from '@/components/ui/Text'
 import { cn } from '@/lib/cn'
 import { achievements } from '@/data/achievements'
 import { useProgress } from '@/lib/progress'
@@ -15,24 +14,20 @@ export default function AchievementGrid() {
           <div
             key={a.id}
             className={cn(
-              'relative rounded-2xl p-6 text-center ring-1 transition-all duration-300',
-              unlocked
-                ? 'bg-[#fff8ec] ring-amber-300'
-                : 'bg-white opacity-40 ring-gray-100 grayscale'
+              'relative rounded-2xl bg-white p-6 text-center ring-1 transition-all duration-300',
+              unlocked ? 'ring-blue-300' : 'opacity-50 ring-gray-100 grayscale'
             )}
           >
             {unlocked && (
-              <span className='absolute -top-2 -right-2 rounded-full bg-amber-500 px-2 py-0.5 text-[10px] font-bold text-white shadow'>
+              <span className='absolute -top-2 -right-2 rounded-full bg-blue-500 px-2 py-0.5 text-[10px] font-extrabold text-white shadow-sm'>
                 NEW
               </span>
             )}
             <div className='mb-3 text-5xl'>{a.emoji}</div>
-            <Text as='caption' className='block font-bold'>
-              {a.title}
-            </Text>
-            <Text as='caption' className='mt-1 block text-gray-500'>
+            <p className='text-sm font-extrabold text-gray-900'>{a.title}</p>
+            <p className='mt-1 text-xs font-medium text-gray-500'>
               {a.description}
-            </Text>
+            </p>
           </div>
         )
       })}

--- a/src/components/quest/Dashboard.tsx
+++ b/src/components/quest/Dashboard.tsx
@@ -21,29 +21,29 @@ export default function Dashboard({
   const badgesTotal = achievements.length
 
   return (
-    <section className='mb-12 rounded-3xl bg-linear-to-br from-[#4576fc] to-[#5f8aff] p-8 text-white shadow-[0_20px_40px_-20px_rgba(69,118,252,0.4)]'>
-      <div className='mb-5 flex flex-wrap items-end justify-between gap-3'>
+    <section className='mb-12 rounded-2xl bg-white p-8 ring-1 ring-gray-100'>
+      <header className='mb-6 flex flex-wrap items-end justify-between gap-3'>
         <div>
-          <div className='text-xl font-semibold tracking-widest uppercase opacity-90'>
+          <h3 className='text-2xl leading-tight font-extrabold text-gray-900'>
             ⚔️ 전체 진도
-          </div>
-          <div className='mt-1 text-sm opacity-85'>
+          </h3>
+          <p className='mt-2 text-sm font-medium text-gray-500'>
             프론트엔드 디자이너의 React 정복 퀘스트
-          </div>
+          </p>
         </div>
-        <div className='font-mono text-5xl leading-none font-bold'>
+        <div className='font-mono text-5xl leading-none font-extrabold text-blue-500'>
           {percent}%
         </div>
-      </div>
+      </header>
 
-      <div className='mb-6 h-3 overflow-hidden rounded-full bg-white/20'>
+      <div className='mb-6 h-2 overflow-hidden rounded-full bg-gray-100'>
         <div
-          className='h-full rounded-full bg-white transition-[width] duration-700 ease-out'
+          className='h-full rounded-full bg-blue-500 transition-[width] duration-700 ease-out'
           style={{ width: `${percent}%` }}
         />
       </div>
 
-      <div className='grid grid-cols-2 gap-4 sm:grid-cols-4'>
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
         <Stat label='🎯 스테이지' value={`${stagesDone} / ${totalStages}`} />
         <Stat label='🧪 예제' value={`— / ${totalExamples}`} />
         <Stat label='📝 블로그' value={`${postsDone} / ${postsTotal}`} />
@@ -55,9 +55,11 @@ export default function Dashboard({
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className='rounded-2xl bg-white/15 p-4 backdrop-blur-md'>
-      <div className='mb-1 text-xs font-semibold opacity-85'>{label}</div>
-      <div className='font-mono text-2xl font-bold'>{value}</div>
+    <div className='rounded-xl bg-gray-50 p-4'>
+      <div className='mb-1 text-xs font-semibold text-gray-500'>{label}</div>
+      <div className='font-mono text-xl font-extrabold text-gray-900'>
+        {value}
+      </div>
     </div>
   )
 }

--- a/src/components/quest/QuestTabs.tsx
+++ b/src/components/quest/QuestTabs.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import Text from '@/components/ui/Text'
 import {
   allStages,
   categoryMeta,
@@ -58,19 +57,19 @@ export default function QuestTabs({ initialTab }: QuestTabsProps) {
         })}
       </nav>
 
-      <header className='mb-6 flex items-baseline gap-3'>
-        <Text as='h4' className='font-extrabold'>
+      <header className='mb-3 flex items-baseline gap-3'>
+        <h3 className='text-2xl font-extrabold text-gray-900'>
           {activeMeta.emoji} {activeMeta.label}
-        </Text>
+        </h3>
         {activeMeta.badge && (
-          <Text as='body' className='font-bold text-[#4576fc]'>
+          <span className='text-sm font-bold text-blue-500'>
             {activeMeta.badge}
-          </Text>
+          </span>
         )}
       </header>
-      <Text as='p' className='mb-8 text-gray-500'>
+      <p className='mb-8 text-sm font-medium text-gray-500'>
         {activeMeta.sublabel}
-      </Text>
+      </p>
 
       <StageList stages={visible} />
     </div>
@@ -99,10 +98,10 @@ function TabButton({
       className={cn(
         'inline-flex shrink-0 items-center gap-2 rounded-full border-2 px-5 py-2.5 text-sm font-bold transition-all duration-200',
         isActive
-          ? 'border-[#4576fc] bg-[#4576fc] text-white shadow-[0_4px_12px_-4px_rgba(69,118,252,0.5)]'
+          ? 'border-blue-500 bg-blue-500 text-white shadow-[0_4px_12px_-4px_rgba(69,118,252,0.5)]'
           : cleared
-            ? 'border-emerald-400 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
-            : 'border-gray-200 bg-white text-gray-700 hover:border-[#4576fc] hover:text-[#4576fc]'
+            ? 'border-blue-300 bg-blue-200 text-blue-700 hover:bg-blue-300'
+            : 'border-gray-200 bg-white text-gray-700 hover:border-blue-500 hover:text-blue-500'
       )}
     >
       <span>{meta.emoji}</span>
@@ -110,7 +109,7 @@ function TabButton({
       {cleared && !isActive && <span className='text-xs'>👑</span>}
       {meta.badge && !cleared && (
         <span
-          className={cn('text-xs', isActive ? 'text-white' : 'text-[#4576fc]')}
+          className={cn('text-xs', isActive ? 'text-white' : 'text-blue-500')}
         >
           {meta.badge}
         </span>
@@ -121,7 +120,7 @@ function TabButton({
           isActive
             ? 'bg-white/20 text-white'
             : cleared
-              ? 'bg-emerald-200 text-emerald-900'
+              ? 'bg-blue-300 text-blue-700'
               : 'bg-gray-100 text-gray-500'
         )}
       >

--- a/src/components/quest/StageCard.tsx
+++ b/src/components/quest/StageCard.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import Text from '@/components/ui/Text'
 import type { Stage } from '@/data/stages'
 import { hasPlayground } from '@/data/playgrounds'
 import { isCompleted, useProgress } from '@/lib/progress'
@@ -36,7 +35,7 @@ export default function StageCard({ stage }: StageCardProps) {
       aria-label={`${stage.title} 상세로 이동`}
       className={cn(
         stageCardVariants({ status: effectiveStatus, boss: stage.isBoss }),
-        'block p-6 focus-visible:ring-2 focus-visible:ring-[#4576fc] focus-visible:outline-none',
+        'block focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none',
         effectiveStatus === 'locked' && 'hover:translate-y-0 hover:shadow-none'
       )}
     >
@@ -46,7 +45,7 @@ export default function StageCard({ stage }: StageCardProps) {
       {done && (
         <div
           aria-hidden
-          className='pointer-events-none absolute top-4 right-5 -rotate-12 rounded-md border-2 border-emerald-500 px-3 py-1 font-mono text-sm font-black tracking-wider text-emerald-500 opacity-90'
+          className='pointer-events-none absolute top-4 right-5 -rotate-12 rounded-md border-2 border-blue-500 px-3 py-1 font-mono text-sm font-black tracking-wider text-blue-500 opacity-90'
         >
           CLEAR!
         </div>
@@ -56,12 +55,12 @@ export default function StageCard({ stage }: StageCardProps) {
         <div className='flex flex-1 items-start gap-4'>
           <span className='shrink-0 text-5xl'>{stage.emoji}</span>
           <div className='flex-1'>
-            <Text as='h6' className='font-extrabold'>
+            <h4 className='text-lg leading-tight font-extrabold text-gray-900'>
               {stage.title}
-            </Text>
-            <Text as='p' className='mt-1 text-gray-500'>
+            </h4>
+            <p className='mt-1 text-sm font-medium text-gray-500'>
               {stage.subtitle}
-            </Text>
+            </p>
             <div className='mt-3 flex flex-wrap items-center gap-2'>
               <span
                 className={difficultyBadge({ difficulty: stage.difficulty })}
@@ -69,15 +68,15 @@ export default function StageCard({ stage }: StageCardProps) {
                 {difficultyLabel[stage.difficulty]}
               </span>
               {stage.highlight && !done && (
-                <Text as='caption' className='font-bold text-[#4576fc]'>
+                <span className='text-xs font-bold text-blue-500'>
                   {stage.highlight}
-                </Text>
+                </span>
               )}
-              <Text as='caption' className='text-gray-500'>
+              <span className='text-xs font-medium text-gray-500'>
                 ⏱ {stage.hours}시간
-              </Text>
+              </span>
               {playgroundReady && (
-                <span className='inline-flex items-center gap-1 rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-bold text-white'>
+                <span className='inline-flex items-center gap-1 rounded-full bg-blue-500 px-2 py-0.5 text-[10px] font-bold text-white'>
                   🕹️ 플레이 가능
                 </span>
               )}
@@ -93,7 +92,7 @@ export default function StageCard({ stage }: StageCardProps) {
           <div className='flex items-center gap-2'>
             <div className='h-1.5 w-24 overflow-hidden rounded-full bg-gray-100'>
               <div
-                className='h-full rounded-full bg-[#4576fc]'
+                className='h-full rounded-full bg-blue-500'
                 style={{
                   width: `${Math.round(
                     (stage.progress.current / stage.progress.total) * 100

--- a/src/components/quest/StageCard.variants.ts
+++ b/src/components/quest/StageCard.variants.ts
@@ -1,18 +1,18 @@
 import { cva } from 'class-variance-authority'
 
 export const stageCardVariants = cva(
-  'relative overflow-hidden rounded-[20px] border-2 p-6 transition-all duration-300',
+  'relative overflow-hidden rounded-2xl bg-white p-6 ring-1 transition-all duration-300',
   {
     variants: {
       status: {
-        locked: 'border-gray-200 bg-gray-50/80 opacity-55',
+        locked: 'opacity-55 ring-gray-100',
         active:
-          'border-[#4576fc] bg-white shadow-[0_0_0_4px_#e7edff] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-8px_rgba(0,0,0,0.1)]',
+          'ring-gray-100 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-8px_rgba(69,118,252,0.25)] hover:ring-blue-300',
         completed:
-          'border-[#10b981] bg-[#d1fae5] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-8px_rgba(0,0,0,0.1)]',
+          'ring-blue-300 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-8px_rgba(69,118,252,0.25)]',
       },
       boss: {
-        true: 'border-[#8b5cf6] bg-gradient-to-br from-white to-[#f5f3ff]',
+        true: 'ring-violet-300',
         false: '',
       },
     },


### PR DESCRIPTION
## Summary
stage-1-rendering 상세페이지 기준으로 홈 섹션들 전체 통일:

- **Dashboard**: 블루 그라디언트 → 화이트 카드 · ring-gray-100 · 블루 프로그레스 바
- **AchievementGrid**: 앰버 배경 제거 → 화이트 카드 + 블루 ring (잠금 해제 상태)
- **StageCard**: 흰 카드 + ring-1 통일 · CLEAR 스탬프 블루 · 완료도 흰 배경 유지
- **QuestTabs**: 헤더 `text-2xl font-extrabold` · 서브 `font-medium text-gray-500` · cleared 탭 에메랄드 → 블루 톤

강(`text-2xl font-extrabold`) → 중(`font-medium text-gray-500`) → 약(`text-base text-gray-700`) 위계 유지.

## Test plan
- [ ] 홈 대시보드 · 뱃지 · 스테이지 카드 모두 흰 배경 확인
- [ ] 텍스트 대비 · 읽기 편함 확인
- [ ] 카테고리 탭 cleared 상태 블루로 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
